### PR TITLE
Fix bond deployment script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -34,8 +34,9 @@ docker run -v $PWD/startup.sh:/app/startup.sh \
     -v $PWD/output:/output \
     -v $PWD/deploy_account.json:/deploy_account.json \
     -e GOOGLE_PROJECT=$GOOGLE_PROJECT \
-    databiosphere/bond:deploy /bin/bash -c \
-    "gcloud auth activate-service-account --key-file=deploy_account.json; python lib/endpoints/endpointscfg.py get_openapi_spec main.BondApi main.BondStatusApi --hostname $GOOGLE_PROJECT.appspot.com --x-google-api-name; gcloud -q endpoints services deploy linkv1openapi.json statusv1openapi.json --project $GOOGLE_PROJECT"
+    --entrypoint "/bin/bash" \
+    databiosphere/bond:deploy \
+    -c "gcloud auth activate-service-account --key-file=deploy_account.json; python lib/endpoints/endpointscfg.py get_openapi_spec main.BondApi main.BondStatusApi --hostname $GOOGLE_PROJECT.appspot.com --x-google-api-name; gcloud -q endpoints services deploy linkv1openapi.json statusv1openapi.json --project $GOOGLE_PROJECT"
 
 #SERVICE_VERSION in app.yaml needs to match the output of the curl call below
 export BUILD_TMP="${HOME}/deploy-bond-${GIT_BRANCH}"
@@ -61,5 +62,6 @@ docker run -v $PWD/startup.sh:/app/startup.sh \
     -v $PWD/config.ini:/app/config.ini \
     -v $PWD/deploy_account.json:/deploy_account.json \
     -e GOOGLE_PROJECT=$GOOGLE_PROJECT \
-    databiosphere/bond:deploy /bin/bash -c \
-    "gcloud auth activate-service-account --key-file=deploy_account.json; gcloud -q app deploy app.yaml --project=$GOOGLE_PROJECT"
+    --entrypoint "/bin/bash" \
+    databiosphere/bond:deploy \
+    -c "gcloud auth activate-service-account --key-file=deploy_account.json; gcloud -q app deploy app.yaml --project=$GOOGLE_PROJECT"


### PR DESCRIPTION
When using the bond docker container in the deployment script we need to specify the entrypoint appropriately.  This should fix the broken bond deploys that broke when the Dockerfile was updated to run Bond in the fiab

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
