### PR TITLE
Fiab Start fix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,15 +3,14 @@ FROM python:2.7.15
 # Prepare the image
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
-    && apt-get install -y -qq --no-install-recommends wget unzip build-essential openssh-client python-openssl \
+    && apt-get install -y -qq --no-install-recommends wget tar build-essential openssh-client python-openssl \
     && apt-get clean
 
 # Install the Google Cloud SDK
 ENV HOME /
 ENV CLOUDSDK_PYTHON_SITEPACKAGES 1
-RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.zip \
-    && unzip google-cloud-sdk.zip \
-    && rm google-cloud-sdk.zip \
+RUN wget -O google-cloud-sdk.tar.gz https://storage.googleapis.com/cloud-sdk-release/google-cloud-sdk-218.0.0-linux-x86.tar.gz \
+    && tar -xzf google-cloud-sdk.tar.gz \
     && google-cloud-sdk/install.sh \
         --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/.bashrc --additional-components \
         app-engine-python app cloud-datastore-emulator app-engine-python-extras


### PR DESCRIPTION
Dockerfile grabs specific v218.0.0 of `gcloud` instead of latest

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
