### PR TITLE
Support for mock-provider

### DIFF
--- a/bond.py
+++ b/bond.py
@@ -40,9 +40,9 @@ class Bond:
         token_response = self.oauth_adapter.exchange_authz_code(authz_code, redirect_uri)
         jwt_token = JwtToken(token_response.get(FenceKeys.ID_TOKEN), self.user_name_path_expr)
         user_id = self.sam_api.user_info(user_info.token)[SamKeys.USER_ID_KEY]
-        if FenceKeys.REFRESH_TOKEN_KEY not in token_response:
-            raise endpoints.BadRequestException("authorization response did not include " + FenceKeys.REFRESH_TOKEN_KEY)
-        TokenStore.save(user_id, token_response.get(FenceKeys.REFRESH_TOKEN_KEY), jwt_token.issued_at,
+        if FenceKeys.REFRESH_TOKEN not in token_response:
+            raise endpoints.BadRequestException("authorization response did not include " + FenceKeys.REFRESH_TOKEN)
+        TokenStore.save(user_id, token_response.get(FenceKeys.REFRESH_TOKEN), jwt_token.issued_at,
                         jwt_token.username, self.provider_name)
         return jwt_token.issued_at, jwt_token.username
 
@@ -58,7 +58,7 @@ class Bond:
         refresh_token = TokenStore.lookup(user_id, self.provider_name)
         if refresh_token is not None:
             token_response = self.oauth_adapter.refresh_access_token(refresh_token.token)
-            expires_at = datetime.fromtimestamp(token_response.get(FenceKeys.EXPIRES_AT_KEY))
+            expires_at = datetime.fromtimestamp(token_response.get(FenceKeys.EXPIRES_AT))
             return token_response.get("access_token"), expires_at
         else:
             raise Bond.MissingTokenError("Could not find refresh token for user")
@@ -94,7 +94,9 @@ class FenceKeys:
     """
     Namespaced set of keys expected to be included in a token response from the Fence OAuth provider.
     """
-    REFRESH_TOKEN_KEY = 'refresh_token'
-    EXPIRES_AT_KEY = 'expires_at'
-    ACCESS_TOKEN_KEY = 'access_token'
+    REFRESH_TOKEN = 'refresh_token'
+    EXPIRES_AT = 'expires_at'
+    EXPIRES_IN = 'expires_in'
+    ACCESS_TOKEN = 'access_token'
     ID_TOKEN = 'id_token'
+    TOKEN_TYPE = 'token_type'

--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -3,6 +3,24 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 {{with $secrets := vault (printf "secret/dsde/bond/%s/config.ini" $environment)}}
 
+{{if eq $runContext "fiab"}}
+
+[fence]
+CLIENT_ID=ignored
+CLIENT_SECRET=ignored
+OPEN_ID_CONFIG_URL=https://storage.googleapis.com/wb-dev-mock-provider/well-known.json
+USER_NAME_PATH_EXPR=/username
+FENCE_BASE_URL=https://us-central1-broad-dsde-dev.cloudfunctions.net
+
+[dcf-fence]
+CLIENT_ID=ignored
+CLIENT_SECRET=ignored
+OPEN_ID_CONFIG_URL=https://storage.googleapis.com/wb-dev-mock-provider/well-known.json
+USER_NAME_PATH_EXPR=/username
+FENCE_BASE_URL=https://us-central1-broad-dsde-dev.cloudfunctions.net
+
+{{else}}
+
 [fence]
 CLIENT_ID={{ $secrets.Data.client_id }}
 CLIENT_SECRET={{ $secrets.Data.client_secret }}
@@ -16,6 +34,8 @@ CLIENT_SECRET={{ $secrets.Data.dcf_fence_client_secret }}
 OPEN_ID_CONFIG_URL={{if eq $environment "prod"}}https://nci-crdc.datacommons.io/user/.well-known/openid-configuration{{else}}https://nci-crdc-staging.datacommons.io/user/.well-known/openid-configuration{{end}}
 USER_NAME_PATH_EXPR=/context/user/name
 FENCE_BASE_URL={{if eq $environment "prod"}}https://nci-crdc.datacommons.io{{else}}https://nci-crdc-staging.datacommons.io{{end}}
+
+{{end}}
 
 [sam]
 BASE_URL={{if eq $runContext "fiab"}}https://sam-fiab.{{$dnsDomain}}{{else}}https://sam.dsde-{{$environment}}.broadinstitute.org{{end}}

--- a/fence_token_vending.py
+++ b/fence_token_vending.py
@@ -111,7 +111,7 @@ class FenceTokenVendingMachine:
         refresh_token = TokenStore.lookup(user_id, self.provider_name)
         if refresh_token is None:
             raise endpoints.BadRequestException("Fence account not linked")
-        access_token = self.fence_oauth_adapter.refresh_access_token(refresh_token.token).get(FenceKeys.ACCESS_TOKEN_KEY)
+        access_token = self.fence_oauth_adapter.refresh_access_token(refresh_token.token).get(FenceKeys.ACCESS_TOKEN)
         return access_token
 
     def _acquire_lock(self, fsa_key):

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import authentication
 from bond import Bond
 from fence_token_vending import FenceTokenVendingMachine
 from fence_api import FenceApi
+from open_id_config import OpenIdConfig
 from sam_api import SamApi
 from oauth_adapter import OauthAdapter
 from status import Status
@@ -93,8 +94,9 @@ class BondApi(remote.Service):
             user_name_path_expr = config.get(provider_name, 'USER_NAME_PATH_EXPR')
 
             sam_base_url = config.get('sam', 'BASE_URL')
-    
-            oauth_adapter = OauthAdapter(client_id, client_secret, open_id_config_url, provider_name)
+
+            open_id_config = OpenIdConfig(provider_name, open_id_config_url)
+            oauth_adapter = OauthAdapter(client_id, client_secret, open_id_config, provider_name)
             fence_api = FenceApi(fence_base_url)
             sam_api = SamApi(sam_base_url)
 

--- a/oauth_adapter.py
+++ b/oauth_adapter.py
@@ -1,12 +1,10 @@
+import base64
+
+import endpoints
+from google.appengine.api import urlfetch
 from requests.auth import HTTPBasicAuth
 from requests_oauthlib import OAuth2Session
 from requests_toolbelt.adapters import appengine
-from google.appengine.api import memcache
-from google.appengine.api import urlfetch
-import endpoints
-import json
-import base64
-
 
 # https://toolbelt.readthedocs.io/en/latest/adapters.html#appengineadapter
 appengine.monkeypatch()
@@ -14,10 +12,10 @@ appengine.monkeypatch()
 
 class OauthAdapter:
 
-    def __init__(self, client_id, client_secret, open_id_config_url, provider_name):
+    def __init__(self, client_id, client_secret, open_id_config, provider_name):
         self.client_id = client_id
         self.client_secret = client_secret
-        self.open_id_config_url = open_id_config_url
+        self.open_id_config = open_id_config
         self.basic_auth = HTTPBasicAuth(self.client_id, self.client_secret)
         self.provider_name = provider_name
 
@@ -31,7 +29,7 @@ class OauthAdapter:
         requires back with the redirect
         :return: A plain (not URL encoded) String
         """
-        authz_endpoint = self._get_open_id_config_value("authorization_endpoint")
+        authz_endpoint = self.open_id_config.get_config_value("authorization_endpoint")
         oauth = OAuth2Session(self.client_id, redirect_uri=redirect_uri, scope=scopes, state=state)
         authorization_url, state = oauth.authorization_url(authz_endpoint)
         return authorization_url
@@ -44,7 +42,7 @@ class OauthAdapter:
         :return: A token dict including the access token, refresh token, and token type (amongst other details)
         """
         oauth = OAuth2Session(self.client_id, redirect_uri=redirect_uri)
-        return oauth.fetch_token(self._get_token_info_url(), code=authz_code, auth=self.basic_auth)
+        return oauth.fetch_token(self.open_id_config.get_token_info_url(), code=authz_code, auth=self.basic_auth)
 
     def refresh_access_token(self, refresh_token_str):
         """
@@ -54,7 +52,7 @@ class OauthAdapter:
         """
         token_dict = {'refresh_token': refresh_token_str}
         oauth = OAuth2Session(self.client_id, token=token_dict)
-        return oauth.refresh_token(self._get_token_info_url(), auth=self.basic_auth)
+        return oauth.refresh_token(self.open_id_config.get_token_info_url(), auth=self.basic_auth)
 
     def revoke_refresh_token(self, refresh_token):
         """
@@ -62,7 +60,7 @@ class OauthAdapter:
         :param refresh_token:
         :return:
         """
-        revoke_url = self._get_revoke_url()
+        revoke_url = self.open_id_config.get_revoke_url()
         result = urlfetch.fetch(url=revoke_url,
                                 method=urlfetch.POST,
                                 payload="token=" + refresh_token,
@@ -70,43 +68,3 @@ class OauthAdapter:
         if result.status_code // 100 != 2:
             raise endpoints.InternalServerErrorException("revoke url {}, status code {}, error body {}".
                                                          format(revoke_url, result.status_code, result.content))
-
-    def _get_open_id_config(self):
-        open_id_config = memcache.get(namespace="OauthAdapter", key=self.provider_name)
-        if not open_id_config:
-            open_id_config_response = urlfetch.fetch(self.open_id_config_url)
-            if open_id_config_response.status_code != 200:
-                raise endpoints.InternalServerErrorException(
-                    message='open_id_config_url [{}] returned status {}: {}'.format(self.open_id_config_url,
-                                                                                    open_id_config_response.status_code,
-                                                                                    open_id_config_response.content))
-            else:
-                open_id_config = json.loads(open_id_config_response.content)
-                memcache.add(namespace="OauthAdapter", key=self.provider_name, value=open_id_config, time=60*60*24)
-        return open_id_config
-
-    def _get_open_id_config_value(self, key, raise_error=True):
-        """
-        Looks in the open_id_config for an entry that matches the provided "key" parameter.  By default, if the key is
-        not found in the config, then an exception will be raised.  This behavior can be disabled by setting the
-        "raise_error" parameter to false.
-        :param key: String value representing the key of the item you want to retrieve from the open_id_config
-        :param raise_error: Boolean - default TRUE - set to false to avoid raising an exception when the "key" cannot be
-        found
-        :return: The object from the open_id_config identified by the "key"
-        """
-        config = self._get_open_id_config()
-        if key in config:
-            return self._get_open_id_config()[key]
-        elif raise_error:
-            raise endpoints.InternalServerErrorException(key + " not found in openid config: " + self.open_id_config_url)
-
-    def _get_token_info_url(self):
-        return self._get_open_id_config_value("token_endpoint")
-
-    def _get_revoke_url(self):
-        revocation_endpoint = self._get_open_id_config_value("revocation_endpoint", False)
-        if revocation_endpoint:
-            return revocation_endpoint
-        else:
-            return self._get_token_info_url().replace("token", "revoke")

--- a/open_id_config.py
+++ b/open_id_config.py
@@ -1,0 +1,52 @@
+import json
+import endpoints
+
+from google.appengine.api import memcache
+from google.appengine.api import urlfetch
+
+
+class OpenIdConfig:
+
+    def __init__(self, provider_name, open_id_config_url):
+        self.provider_name = provider_name
+        self.open_id_config_url = open_id_config_url
+
+    def load_dict(self):
+        open_id_dict = memcache.get(namespace="OauthAdapter", key=self.provider_name)
+        if not open_id_dict:
+            open_id_config_response = urlfetch.fetch(self.open_id_config_url)
+            if open_id_config_response.status_code != 200:
+                raise endpoints.InternalServerErrorException(
+                    message='open_id_config_url [{}] returned status {}: {}'.format(self.open_id_config_url,
+                                                                                    open_id_config_response.status_code,
+                                                                                    open_id_config_response.content))
+            else:
+                open_id_dict = json.loads(open_id_config_response.content)
+                memcache.add(namespace="OauthAdapter", key=self.provider_name, value=open_id_dict, time=60*60*24)
+        return open_id_dict
+
+    def get_config_value(self, key, raise_error=True):
+        """
+        Looks in the open_id_config for an entry that matches the provided "key" parameter.  By default, if the key is
+        not found in the config, then an exception will be raised.  This behavior can be disabled by setting the
+        "raise_error" parameter to false.
+        :param key: String value representing the key of the item you want to retrieve from the open_id_config
+        :param raise_error: Boolean - default TRUE - set to false to avoid raising an exception when the "key" cannot be
+        found
+        :return: The object from the open_id_config identified by the "key"
+        """
+        config = self.load_dict()
+        if key in config:
+            return self.load_dict()[key]
+        elif raise_error:
+            raise endpoints.InternalServerErrorException(key + " not found in openid config: " + self.open_id_config_url)
+
+    def get_token_info_url(self):
+        return self.get_config_value("token_endpoint")
+
+    def get_revoke_url(self):
+        revocation_endpoint = self.get_config_value("revocation_endpoint", False)
+        if revocation_endpoint:
+            return revocation_endpoint
+        else:
+            return self.get_token_info_url().replace("token", "revoke")

--- a/tests/integration/oauth_adapter_test.py
+++ b/tests/integration/oauth_adapter_test.py
@@ -1,6 +1,8 @@
 import ConfigParser
 import unittest
 import endpoints
+import re
+import urllib
 
 from google.appengine.ext import testbed
 from oauth_adapter import OauthAdapter
@@ -10,40 +12,70 @@ class OauthAdapterTestCase(unittest.TestCase):
 
     def setUp(self):
         super(OauthAdapterTestCase, self).setUp()
+
         self.tb = testbed.Testbed()
         self.tb.activate()
         self.tb.init_memcache_stub()
         self.tb.init_urlfetch_stub()
+
+        self.url_prefix_regex = "^http(s)?:\/\/[a-z0-9_\-]+(\.[a-z0-9_\-]+)+"
         config = ConfigParser.ConfigParser()
         config.read("config.ini")
-        self.provider = "fence"
-        self.client_id = config.get(self.provider, 'CLIENT_ID')
-        self.client_secret = config.get(self.provider, 'CLIENT_SECRET')
-        self.open_id_config_url = config.get(self.provider, 'OPEN_ID_CONFIG_URL')
-        self.oauth_adapter = OauthAdapter(self.client_id, self.client_secret, self.open_id_config_url, self.provider)
+        self.oauth_adapters = {}
+        for section in config.sections():
+            if section != "sam":
+                client_id = config.get(section, 'CLIENT_ID')
+                client_secret = config.get(section, 'CLIENT_SECRET')
+                open_id_config_url = config.get(section, 'OPEN_ID_CONFIG_URL')
+                self.oauth_adapters[section] = OauthAdapter(client_id, client_secret, open_id_config_url, section)
 
     def tearDown(self):
         self.tb.deactivate()
         super(OauthAdapterTestCase, self).tearDown()
 
+    @staticmethod
+    def param_regex(key, value):
+        return "[\?&]" + re.escape(key) + "=" + re.escape(value) + "[&]?"
+
     def test_get_open_id_config(self):
-        open_id_config = self.oauth_adapter._get_open_id_config()
-        self.assertIsNotNone(open_id_config)
+        for provider, oauth_adapter in self.oauth_adapters.iteritems():
+            open_id_config = oauth_adapter._get_open_id_config()
+            self.assertIsNotNone(open_id_config, "Expected open_id_config for " + provider + " to not be None")
 
     def test_get_open_id_config_value(self):
-        key = "scopes_supported"
-        self.assertTrue(len(self.oauth_adapter._get_open_id_config_value(key)),
-                        "Expected key \"" + key + "\" to be a non-empty array")
+        for provider, oauth_adapter in self.oauth_adapters.iteritems():
+            key = "scopes_supported"
+            self.assertTrue(len(oauth_adapter._get_open_id_config_value(key)),
+                            "Expected key \"" + key + "\" to be a non-empty array for provider " + provider)
 
     def test_get_open_id_config_value_missing(self):
-        with self.assertRaises(endpoints.InternalServerErrorException):
-            self.oauth_adapter._get_open_id_config_value("something-that-does-not-exist")
+        for provider, oauth_adapter in self.oauth_adapters.iteritems():
+            with self.assertRaises(endpoints.InternalServerErrorException):
+                oauth_adapter._get_open_id_config_value("something-that-does-not-exist")
 
     def test_get_open_id_config_value_missing_no_exception(self):
-        self.assertIsNone(self.oauth_adapter._get_open_id_config_value("something-that-does-not-exist", False))
+        for provider, oauth_adapter in self.oauth_adapters.iteritems():
+            self.assertIsNone(oauth_adapter._get_open_id_config_value("something-that-does-not-exist", False))
 
     def test_get_token_info_url(self):
-        self.assertRegexpMatches(self.oauth_adapter._get_token_info_url(), "^http(s)?:\/\/[a-z0-9_\-]+(\.[a-z0-9_\-]+)+")
+        for provider, oauth_adapter in self.oauth_adapters.iteritems():
+            token_info_url = oauth_adapter._get_token_info_url()
+            self.assertRegexpMatches(token_info_url, self.url_prefix_regex, "Token Info URL for provider " + provider)
 
     def test_get_revoke_url(self):
-        self.assertRegexpMatches(self.oauth_adapter._get_revoke_url(), "^http(s)?:\/\/.+?revoke")
+        url_regex = "^http(s)?:\/\/.+?revoke"
+        for provider, oauth_adapter in self.oauth_adapters.iteritems():
+            self.assertRegexpMatches(oauth_adapter._get_revoke_url(), url_regex, "Revoke URL for provider " + provider)
+
+    def test_build_authz_url(self):
+        scopes = ["foo", "bar"]
+        redirect_uri = "http://something.something/"
+        state = "abc123"
+        for provider, oauth_adapter in self.oauth_adapters.iteritems():
+            authz_url = oauth_adapter.build_authz_url(scopes, redirect_uri, state)
+            msg = "For provider: " + provider
+            self.assertRegexpMatches(authz_url, self.url_prefix_regex, msg)
+            self.assertRegexpMatches(authz_url, self.param_regex("response_type", "code"), msg)
+            self.assertRegexpMatches(authz_url, self.param_regex("scope", "+".join(scopes)), msg)
+            self.assertRegexpMatches(authz_url, self.param_regex("redirect_uri", urllib.quote_plus(redirect_uri)), msg)
+            self.assertRegexpMatches(authz_url, self.param_regex("state", state), msg)

--- a/tests/integration/oauth_adapter_test.py
+++ b/tests/integration/oauth_adapter_test.py
@@ -1,6 +1,5 @@
 import ConfigParser
 import unittest
-import endpoints
 import re
 import urllib
 import sys
@@ -16,25 +15,56 @@ from open_id_config import OpenIdConfig
 
 class OauthAdapterTestCase(unittest.TestCase):
 
+    url_prefix_regex = "^http(s)?:\/\/[a-z0-9_\-]+(\.[a-z0-9_\-]+)+"
+    config = None
+    oauth_adapters = {}
+    authz_responses = {}
+
+    @classmethod
+    def setUpClass(cls):
+        OauthAdapterTestCase.config = ConfigParser.ConfigParser()
+        OauthAdapterTestCase.config.read("config.ini")
+        OauthAdapterTestCase.oauth_adapters = OauthAdapterTestCase.init_oauth_adapters(OauthAdapterTestCase.config)
+        OauthAdapterTestCase.authz_responses = OauthAdapterTestCase.authorize_with_providers(OauthAdapterTestCase.oauth_adapters)
+
+    @classmethod
+    def init_oauth_adapters(cls, config):
+        oauth_adapters = {}
+        for section in config.sections():
+            if section != "sam":
+                client_id = config.get(section, 'CLIENT_ID')
+                client_secret = config.get(section, 'CLIENT_SECRET')
+                open_id_config_url = config.get(section, 'OPEN_ID_CONFIG_URL')
+                open_id_config = OpenIdConfig(section, open_id_config_url)
+                oauth_adapters[section] = OauthAdapter(client_id, client_secret, open_id_config, section)
+        return oauth_adapters
+
+    @classmethod
+    def authorize_with_providers(cls, oauth_adapters):
+        local_tb = testbed.Testbed()
+        local_tb.activate()
+        local_tb.init_memcache_stub()
+        local_tb.init_urlfetch_stub()
+        scopes = ["openid", "google_credentials"]
+        redirect_uri = "http://local.broadinstitute.org/#fence-callback"
+        state = "abc123"
+        authz_responses = {}
+        for provider, oauth_adapter in oauth_adapters.iteritems():
+            authz_url = oauth_adapter.build_authz_url(scopes, redirect_uri, state)
+            print("Please go to %s to authorize access: %s" % (provider, authz_url))
+            print("Please copy/paste the \"code\" parameter from the resulting URL: ")
+            sys.stdout.flush()
+            auth_code = sys.stdin.readline().strip()
+            authz_responses[provider] = oauth_adapter.exchange_authz_code(auth_code, redirect_uri)
+        local_tb.deactivate()
+        return authz_responses
+
     def setUp(self):
         super(OauthAdapterTestCase, self).setUp()
-
         self.tb = testbed.Testbed()
         self.tb.activate()
         self.tb.init_memcache_stub()
         self.tb.init_urlfetch_stub()
-
-        self.url_prefix_regex = "^http(s)?:\/\/[a-z0-9_\-]+(\.[a-z0-9_\-]+)+"
-        self.config = ConfigParser.ConfigParser()
-        self.config.read("config.ini")
-        self.oauth_adapters = {}
-        for section in self.config.sections():
-            if section != "sam":
-                client_id = self.config.get(section, 'CLIENT_ID')
-                client_secret = self.config.get(section, 'CLIENT_SECRET')
-                open_id_config_url = self.config.get(section, 'OPEN_ID_CONFIG_URL')
-                open_id_config = OpenIdConfig(section, open_id_config_url)
-                self.oauth_adapters[section] = OauthAdapter(client_id, client_secret, open_id_config, section)
 
     def tearDown(self):
         self.tb.deactivate()
@@ -66,27 +96,33 @@ class OauthAdapterTestCase(unittest.TestCase):
             self.assertRegexpMatches(authz_url, self.param_regex("state", state), msg)
 
     def test_exchange_authz_code(self):
-        scopes = ['openid', 'google_credentials']
-        redirect_uri = "http://local.broadinstitute.org/#fence-callback"
-        state = "abc123"
-        for provider, oauth_adapter in self.oauth_adapters.iteritems():
-            authz_url = oauth_adapter.build_authz_url(scopes, redirect_uri, state)
-            print('Please go to %s and authorize access for %s.' % (authz_url, provider))
-            print("Please copy/paste the \"code\" parameter from the resulting URL: ")
-            sys.stdout.flush()
-            auth_code = sys.stdin.readline().strip()
-            authz = oauth_adapter.exchange_authz_code(auth_code, redirect_uri)
+        # The calls to `exchange_authz_code` happen in the `setUpClass` method so that they are only called once for
+        # this test suite
+        for provider, authz in self.authz_responses.iteritems():
+            self.assert_token_response(authz, provider)
 
-            self.assertEqual("Bearer", authz[FenceKeys.TOKEN_TYPE], "Token type should be \"Bearer\" for provider: " + provider)
-            self.assertTrue(authz[FenceKeys.REFRESH_TOKEN], "Missing refresh_token for provider: " + provider)
-            self.assertTrue(authz[FenceKeys.ACCESS_TOKEN], "Missing access_token for provider: " + provider)
-            self.assertTrue(authz[FenceKeys.ID_TOKEN], "Missing id_token for provider: " + provider)
-            jwt_token = JwtToken(authz[FenceKeys.ID_TOKEN], self.config.get(provider, "USER_NAME_PATH_EXPR"))
-            self.assertIsNotNone(jwt_token.username)
-            self.assertIsNotNone(jwt_token.issued_at)
-            self.assertIs(type(authz[FenceKeys.EXPIRES_IN]), int, "Value of expires_in for provider: " + provider + " should be of type: int")
-            self.assertGreater(authz[FenceKeys.EXPIRES_IN], 0, "Value of expires_in for provider: " + provider + " should be greater than 0")
-            self.assertIs(type(authz[FenceKeys.EXPIRES_AT]), float, "Value of expires_at for provider: " + provider + " should be of type: float")
-            self.assertGreater(authz[FenceKeys.EXPIRES_AT], 0, "Value of expires_at for provider: " + provider + " should be greater than 0")
-            calculated_expiry = time.time() + authz[FenceKeys.EXPIRES_IN]
-            self.assertAlmostEqual(authz[FenceKeys.EXPIRES_AT], calculated_expiry, delta=60, msg="Value of expires_at for provider: " + provider + " should be an epoch time in seconds that is within 60 seconds of the current time plus the value of the expires_in field")
+    def test_refresh_access_token(self):
+        for provider, authz in self.authz_responses.iteritems():
+            if provider != "dcf-fence":
+                oauth_adapter = self.oauth_adapters[provider]
+                refresh_token = authz[FenceKeys.REFRESH_TOKEN]
+                self.assert_token_response(oauth_adapter.refresh_access_token(refresh_token), provider)
+
+    @unittest.skip("Test should be implemented.  Saving time now by not implementing so we can get mock Fence working")
+    def test_revoke_refresh_token(self):
+        self.assertTrue(False, "This test needs to be implemented")
+
+    def assert_token_response(self, authz, provider):
+        self.assertEqual("Bearer", authz[FenceKeys.TOKEN_TYPE], "Token type should be \"Bearer\" for provider: " + provider)
+        self.assertTrue(authz[FenceKeys.REFRESH_TOKEN], "Missing refresh_token for provider: " + provider)
+        self.assertTrue(authz[FenceKeys.ACCESS_TOKEN], "Missing access_token for provider: " + provider)
+        self.assertTrue(authz[FenceKeys.ID_TOKEN], "Missing id_token for provider: " + provider)
+        jwt_token = JwtToken(authz[FenceKeys.ID_TOKEN], self.config.get(provider, "USER_NAME_PATH_EXPR"))
+        self.assertIsNotNone(jwt_token.username)
+        self.assertIsNotNone(jwt_token.issued_at)
+        self.assertIs(type(authz[FenceKeys.EXPIRES_IN]), int, "Value of expires_in for provider: " + provider + " should be of type: int")
+        self.assertGreater(authz[FenceKeys.EXPIRES_IN], 0, "Value of expires_in for provider: " + provider + " should be greater than 0")
+        self.assertIs(type(authz[FenceKeys.EXPIRES_AT]), float, "Value of expires_at for provider: " + provider + " should be of type: float")
+        self.assertGreater(authz[FenceKeys.EXPIRES_AT], 0, "Value of expires_at for provider: " + provider + " should be greater than 0")
+        calculated_expiry = time.time() + authz[FenceKeys.EXPIRES_IN]
+        self.assertAlmostEqual(authz[FenceKeys.EXPIRES_AT], calculated_expiry, delta=60, msg="Value of expires_at for provider: " + provider + " should be an epoch time in seconds that is within 60 seconds of the current time plus the value of the expires_in field")

--- a/tests/unit/bond_test.py
+++ b/tests/unit/bond_test.py
@@ -37,10 +37,10 @@ class BondTestCase(unittest.TestCase):
 
         data = {"context": {"user": {"name": self.name}}, 'iat': self.issued_at_epoch}
         encoded_jwt = jwt.encode(data, 'secret', 'HS256')
-        fake_token_dict = {FenceKeys.ACCESS_TOKEN_KEY: self.fake_access_token,
-                           FenceKeys.REFRESH_TOKEN_KEY: str(uuid.uuid4()),
+        fake_token_dict = {FenceKeys.ACCESS_TOKEN: self.fake_access_token,
+                           FenceKeys.REFRESH_TOKEN: str(uuid.uuid4()),
                            FenceKeys.ID_TOKEN: encoded_jwt,
-                           FenceKeys.EXPIRES_AT_KEY: self.expires_at_epoch}
+                           FenceKeys.EXPIRES_AT: self.expires_at_epoch}
 
         mock_oauth_adapter = OauthAdapter("foo", "bar", "baz", "qux")
         mock_oauth_adapter.exchange_authz_code = MagicMock(return_value=fake_token_dict, name="exchange_authz_code")
@@ -66,9 +66,9 @@ class BondTestCase(unittest.TestCase):
     def test_exchange_authz_code_missing_token(self):
         data = {"context": {"user": {"name": self.name}}, 'iat': self.issued_at_epoch}
         encoded_jwt = jwt.encode(data, 'secret', 'HS256')
-        fake_token_dict = {FenceKeys.ACCESS_TOKEN_KEY: self.fake_access_token,
+        fake_token_dict = {FenceKeys.ACCESS_TOKEN: self.fake_access_token,
                            FenceKeys.ID_TOKEN: encoded_jwt,
-                           FenceKeys.EXPIRES_AT_KEY: self.expires_at_epoch}
+                           FenceKeys.EXPIRES_AT: self.expires_at_epoch}
 
         mock_oauth_adapter = OauthAdapter("foo", "bar", "baz", "qux")
         mock_oauth_adapter.exchange_authz_code = MagicMock(return_value=fake_token_dict)

--- a/tests/unit/open_id_config_test.py
+++ b/tests/unit/open_id_config_test.py
@@ -1,0 +1,40 @@
+import unittest
+import endpoints
+
+from mock import MagicMock
+from open_id_config import OpenIdConfig
+
+
+class OpenIdConfigTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.url_prefix_regex = "^http(s)?:\/\/[a-z0-9_\-]+(\.[a-z0-9_\-]+)+"
+        fake_config = {"token_endpoint": "https://fake.domain/user/oauth2/token",
+                       "revocation_endpoint": "",
+                       "scopes_supported": ["foo", "bar"]}
+        self.provider = "fake_provider"
+        self.open_id_config = OpenIdConfig(self.provider, "not-a-real-url")
+        self.open_id_config.load_dict = MagicMock(return_value=fake_config)
+
+    def test_get_config(self):
+        open_id_config = self.open_id_config.load_dict()
+        self.assertIsNotNone(open_id_config)
+
+    def test_get_value(self):
+        key = "scopes_supported"
+        self.assertIsNotNone(self.open_id_config.get_config_value(key))
+
+    def test_get_open_id_config_value_missing(self):
+        with self.assertRaises(endpoints.InternalServerErrorException):
+            self.open_id_config.get_config_value("something-that-does-not-exist")
+
+    def test_get_open_id_config_value_missing_no_exception(self):
+        self.assertIsNone(self.open_id_config.get_config_value("something-that-does-not-exist", False))
+
+    def test_get_token_info_url(self):
+        token_info_url = self.open_id_config.get_token_info_url()
+        self.assertRegexpMatches(token_info_url, self.url_prefix_regex)
+
+    def test_get_revoke_url(self):
+        url_regex = "^http(s)?:\/\/.+?revoke"
+        self.assertRegexpMatches(self.open_id_config.get_revoke_url(), url_regex)


### PR DESCRIPTION
- Refactored OpenID Config into its own class
- Renamed some constants for clarity/brevity
- Added more robust oauth_adapter tests for asserting that real or mock providers work as expected

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
