### PR TITLE
[GAWB-4005] Config change to use mock provider with FiaBs

### DIFF
--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -17,7 +17,7 @@ CLIENT_ID=ignored
 CLIENT_SECRET=ignored
 OPEN_ID_CONFIG_URL=https://storage.googleapis.com/wb-dev-mock-provider/well-known.json
 USER_NAME_PATH_EXPR=/username
-FENCE_BASE_URL=https://broadinstitute.org
+FENCE_BASE_URL=https://nci-crdc-staging.datacommons.io
 
 {{else}}
 

--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -3,6 +3,24 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 {{with $secrets := vault (printf "secret/dsde/bond/%s/config.ini" $environment)}}
 
+{{if eq $runContext "fiab"}}
+
+[fence]
+CLIENT_ID=ignored
+CLIENT_SECRET=ignored
+OPEN_ID_CONFIG_URL=https://storage.googleapis.com/wb-dev-mock-provider/well-known.json
+USER_NAME_PATH_EXPR=/username
+FENCE_BASE_URL=https://dcp.bionimbus.org
+
+[dcf-fence]
+CLIENT_ID=ignored
+CLIENT_SECRET=ignored
+OPEN_ID_CONFIG_URL=https://storage.googleapis.com/wb-dev-mock-provider/well-known.json
+USER_NAME_PATH_EXPR=/username
+FENCE_BASE_URL=https://broadinstitute.org
+
+{{else}}
+
 [fence]
 CLIENT_ID={{ $secrets.Data.client_id }}
 CLIENT_SECRET={{ $secrets.Data.client_secret }}
@@ -16,6 +34,8 @@ CLIENT_SECRET={{ $secrets.Data.dcf_fence_client_secret }}
 OPEN_ID_CONFIG_URL={{if eq $environment "prod"}}https://nci-crdc.datacommons.io/user/.well-known/openid-configuration{{else}}https://nci-crdc-staging.datacommons.io/user/.well-known/openid-configuration{{end}}
 USER_NAME_PATH_EXPR=/context/user/name
 FENCE_BASE_URL={{if eq $environment "prod"}}https://nci-crdc.datacommons.io{{else}}https://nci-crdc-staging.datacommons.io{{end}}
+
+{{end}}
 
 [sam]
 BASE_URL={{if eq $runContext "fiab"}}https://sam-fiab.{{$dnsDomain}}{{else}}https://sam.dsde-{{$environment}}.broadinstitute.org{{end}}

--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -10,14 +10,14 @@ CLIENT_ID=ignored
 CLIENT_SECRET=ignored
 OPEN_ID_CONFIG_URL=https://storage.googleapis.com/wb-dev-mock-provider/well-known.json
 USER_NAME_PATH_EXPR=/username
-FENCE_BASE_URL=https://dcp.bionimbus.org
+FENCE_BASE_URL=https://us-central1-broad-dsde-dev.cloudfunctions.net
 
 [dcf-fence]
 CLIENT_ID=ignored
 CLIENT_SECRET=ignored
 OPEN_ID_CONFIG_URL=https://storage.googleapis.com/wb-dev-mock-provider/well-known.json
 USER_NAME_PATH_EXPR=/username
-FENCE_BASE_URL=https://nci-crdc-staging.datacommons.io
+FENCE_BASE_URL=https://us-central1-broad-dsde-dev.cloudfunctions.net
 
 {{else}}
 


### PR DESCRIPTION
[GAWB-4005](https://broadinstitute.atlassian.net/browse/GAWB-4005)

These changes to the configs make Bond perform the OAuth dance with the mock provider rather than the actual services when it is running in a FiaB. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
