### PR TITLE
Circle builds docker image and runs tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           name: Push image to quay.io
           command: |
             docker login -u="${QUAY_USER}" -p="${QUAY_USER_PW}" quay.io
-            docker push databiosphere/bond:${CIRCLE_BRANCH}
+            docker push quay.io/databiosphere/bond:${CIRCLE_BRANCH}
 
   tag:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,17 @@ jobs:
             source virtualenv/bin/activate
             python tests/test_runner.py `gcloud info --format="value(installation.sdk_root)"`
 
+  build-docker-image:
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Build and test docker image
+          command: |
+            docker build -t databiosphere/bond:foo -f docker/Dockerfile .
+            docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:foo -c "python tests/test_runner.py /google-cloud-sdk --test-path=tests/integration"
+
   tag:
     docker:
       - image: alpine/git
@@ -69,3 +80,4 @@ workflows:
           filters:
             branches:
               only: develop
+      - build-docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
   build-docker-image:
     docker:
       - image: circleci/python:2.7.14
+
     steps:
       - checkout
 
@@ -58,12 +59,26 @@ jobs:
       - run:
           name: Run functional tests
           command: |
-            docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:foo -c "./tests/functional_test.sh"
+            docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:foobar -c "./tests/functional_test.sh"
 
       - run:
           name: Push image to quay.io
           command: |
             echo "TODO: Implement this step!"
+
+  run-functional-tests:
+    docker:
+      - image: circleci/python:2.7.14
+
+    steps:
+
+#      - setup_remote_docker:
+#          docker_layer_caching: true
+
+      - run:
+          name: Run functional tests
+          command: |
+            docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:foobar -c "./tests/functional_test.sh"
 
   tag:
     docker:
@@ -95,3 +110,6 @@ workflows:
             branches:
               only: develop
       - build-docker-image
+      - run-functional-tests:
+          requires:
+            - build-docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - run:
           name: Build image
           command: |
-            docker build -t databiosphere/bond:foo -f docker/Dockerfile .
+            docker build -t databiosphere/bond:foobar -f docker/Dockerfile .
 
       - run:
           name: Run functional tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,8 @@ jobs:
             python tests/test_runner.py `gcloud info --format="value(installation.sdk_root)"`
 
   build-docker-image:
+    docker:
+      - image: circleci/python:2.7.14
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,18 @@ jobs:
       - image: circleci/python:2.7.14
     steps:
       - checkout
+
       - setup_remote_docker:
           docker_layer_caching: true
+
       - run:
           name: Build and test docker image
           command: |
             docker build -t databiosphere/bond:foo -f docker/Dockerfile .
+
+      - run:
+          name: Run functional tests
+          command: |
             docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:foo -c "python tests/test_runner.py /google-cloud-sdk --test-path=tests/integration"
 
   tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           docker_layer_caching: true
 
       - run:
-          name: Build and test docker image
+          name: Build image
           command: |
             docker build -t databiosphere/bond:foo -f docker/Dockerfile .
 
@@ -59,6 +59,11 @@ jobs:
           name: Run functional tests
           command: |
             docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:foo -c "./tests/functional_test.sh"
+
+      - run:
+          name: Push image to quay.io
+          command: |
+            echo "TODO: Implement this step!"
 
   tag:
     docker:
@@ -85,6 +90,7 @@ workflows:
       - tag:
           requires:
             - test
+            - build-docker-image
           filters:
             branches:
               only: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - run:
           name: Run functional tests
           command: |
-            docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:foo -c "python tests/test_runner.py /google-cloud-sdk --test-path=tests/integration"
+            docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:foo -c "./tests/functional_test.sh"
 
   tag:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,29 +56,15 @@ jobs:
           command: |
             docker build -t databiosphere/bond:foobar -f docker/Dockerfile .
 
-#      - run:
-#          name: Run functional tests
-#          command: |
-#            docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:foobar -c "./tests/functional_test.sh"
+      - run:
+          name: Run functional tests
+          command: |
+            docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:foobar -c "./tests/functional_test.sh"
 
       - run:
           name: Push image to quay.io
           command: |
             echo "TODO: Implement this step!"
-
-  run-functional-tests:
-    docker:
-      - image: circleci/python:2.7.15
-
-    steps:
-
-      - setup_remote_docker:
-          docker_layer_caching: true
-
-      - run:
-          name: Run functional tests
-          command: |
-            docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:foobar -c "./tests/functional_test.sh"
 
   tag:
     docker:
@@ -110,6 +96,3 @@ workflows:
             branches:
               only: develop
       - build-docker-image
-      - run-functional-tests:
-          requires:
-            - build-docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,9 @@ jobs:
     docker:
       - image: circleci/python:2.7.15
 
+    environment:
+      QUAY_USER: databiosphere+bond_circle_bot
+
     steps:
       - checkout
 
@@ -54,17 +57,18 @@ jobs:
       - run:
           name: Build image
           command: |
-            docker build -t databiosphere/bond:foobar -f docker/Dockerfile .
+            docker build -t databiosphere/bond:${CIRCLE_BRANCH} -f docker/Dockerfile .
 
       - run:
           name: Run functional tests
           command: |
-            docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:foobar -c "./tests/functional_test.sh"
+            docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:${CIRCLE_BRANCH} -c "./tests/functional_test.sh"
 
       - run:
           name: Push image to quay.io
           command: |
-            echo "TODO: Implement this step!"
+            docker login -u="${QUAY_USER}" -p="${QUAY_USER_PW}" quay.io
+            docker push databiosphere/bond:${CIRCLE_BRANCH}
 
   tag:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
 
   build-docker-image:
     docker:
-      - image: circleci/python:2.7.14
+      - image: circleci/python:2.7.15
 
     steps:
       - checkout
@@ -56,10 +56,10 @@ jobs:
           command: |
             docker build -t databiosphere/bond:foobar -f docker/Dockerfile .
 
-      - run:
-          name: Run functional tests
-          command: |
-            docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:foobar -c "./tests/functional_test.sh"
+#      - run:
+#          name: Run functional tests
+#          command: |
+#            docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:foobar -c "./tests/functional_test.sh"
 
       - run:
           name: Push image to quay.io
@@ -68,12 +68,12 @@ jobs:
 
   run-functional-tests:
     docker:
-      - image: circleci/python:2.7.14
+      - image: circleci/python:2.7.15
 
     steps:
 
-#      - setup_remote_docker:
-#          docker_layer_caching: true
+      - setup_remote_docker:
+          docker_layer_caching: true
 
       - run:
           name: Run functional tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
 
     environment:
       QUAY_USER: databiosphere+bond_circle_bot
-      IMAGE_ID: quay.io/databiosphere/bond:${CIRCLE_BRANCH}
+      IMAGE_NAME: quay.io/databiosphere/bond
 
     steps:
       - checkout
@@ -58,18 +58,18 @@ jobs:
       - run:
           name: Build image
           command: |
-            docker build -t ${IMAGE_ID} -f docker/Dockerfile .
+            docker build -t ${IMAGE_NAME}:${CIRCLE_BRANCH} -f docker/Dockerfile .
 
       - run:
           name: Run functional tests
           command: |
-            docker run --entrypoint /bin/bash --workdir "/app" ${IMAGE_ID} -c "./tests/functional_test.sh"
+            docker run --entrypoint /bin/bash --workdir "/app" ${IMAGE_NAME}:${CIRCLE_BRANCH} -c "./tests/functional_test.sh"
 
       - run:
           name: Push image to quay.io
           command: |
             docker login -u="${QUAY_USER}" -p="${QUAY_USER_PW}" quay.io
-            docker push ${IMAGE_ID}
+            docker push ${IMAGE_NAME}:${CIRCLE_BRANCH}
 
   tag:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,12 +57,12 @@ jobs:
       - run:
           name: Build image
           command: |
-            docker build -t databiosphere/bond:${CIRCLE_BRANCH} -f docker/Dockerfile .
+            docker build -t quay.io/databiosphere/bond:${CIRCLE_BRANCH} -f docker/Dockerfile .
 
       - run:
           name: Run functional tests
           command: |
-            docker run --entrypoint /bin/bash --workdir "/app" databiosphere/bond:${CIRCLE_BRANCH} -c "./tests/functional_test.sh"
+            docker run --entrypoint /bin/bash --workdir "/app" quay.io/databiosphere/bond:${CIRCLE_BRANCH} -c "./tests/functional_test.sh"
 
       - run:
           name: Push image to quay.io

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
 
     environment:
       QUAY_USER: databiosphere+bond_circle_bot
+      IMAGE_ID: quay.io/databiosphere/bond:${CIRCLE_BRANCH}
 
     steps:
       - checkout
@@ -57,18 +58,18 @@ jobs:
       - run:
           name: Build image
           command: |
-            docker build -t quay.io/databiosphere/bond:${CIRCLE_BRANCH} -f docker/Dockerfile .
+            docker build -t ${IMAGE_ID} -f docker/Dockerfile .
 
       - run:
           name: Run functional tests
           command: |
-            docker run --entrypoint /bin/bash --workdir "/app" quay.io/databiosphere/bond:${CIRCLE_BRANCH} -c "./tests/functional_test.sh"
+            docker run --entrypoint /bin/bash --workdir "/app" ${IMAGE_ID} -c "./tests/functional_test.sh"
 
       - run:
           name: Push image to quay.io
           command: |
             docker login -u="${QUAY_USER}" -p="${QUAY_USER_PW}" quay.io
-            docker push quay.io/databiosphere/bond:${CIRCLE_BRANCH}
+            docker push ${IMAGE_ID}
 
   tag:
     docker:

--- a/tests/config/config.ini
+++ b/tests/config/config.ini
@@ -1,0 +1,9 @@
+[mock-fence]
+CLIENT_ID=ignored
+CLIENT_SECRET=ignored
+OPEN_ID_CONFIG_URL=https://storage.googleapis.com/wb-dev-mock-provider/well-known.json
+USER_NAME_PATH_EXPR=/username
+FENCE_BASE_URL=https://us-central1-broad-dsde-dev.cloudfunctions.net
+
+[sam]
+BASE_URL=https://sam.dsde-dev.broadinstitute.org

--- a/tests/functional_test.sh
+++ b/tests/functional_test.sh
@@ -3,3 +3,5 @@
 cp tests/config/config.ini config.ini
 
 python tests/test_runner.py /google-cloud-sdk --test-path=tests/integration
+
+exit 1

--- a/tests/functional_test.sh
+++ b/tests/functional_test.sh
@@ -3,5 +3,3 @@
 cp tests/config/config.ini config.ini
 
 python tests/test_runner.py /google-cloud-sdk --test-path=tests/integration
-
-exit 1

--- a/tests/functional_test.sh
+++ b/tests/functional_test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cp tests/config/config.ini config.ini
+
+python tests/test_runner.py /google-cloud-sdk --test-path=tests/integration

--- a/tests/integration/oauth_adapter_test.py
+++ b/tests/integration/oauth_adapter_test.py
@@ -54,7 +54,7 @@ class OauthAdapterTestCase(unittest.TestCase):
             print("Please go to %s to authorize access: %s" % (provider, authz_url))
             print("Please copy/paste the \"code\" parameter from the resulting URL: ")
             sys.stdout.flush()
-            auth_code = sys.stdin.readline().strip()
+            # auth_code = sys.stdin.readline().strip()
             authz_responses[provider] = oauth_adapter.exchange_authz_code(auth_code, redirect_uri)
         local_tb.deactivate()
         return authz_responses

--- a/tests/integration/oauth_adapter_test.py
+++ b/tests/integration/oauth_adapter_test.py
@@ -55,6 +55,7 @@ class OauthAdapterTestCase(unittest.TestCase):
             print("Please copy/paste the \"code\" parameter from the resulting URL: ")
             sys.stdout.flush()
             # auth_code = sys.stdin.readline().strip()
+            auth_code = "X"
             authz_responses[provider] = oauth_adapter.exchange_authz_code(auth_code, redirect_uri)
         local_tb.deactivate()
         return authz_responses


### PR DESCRIPTION
This PR does a couple of things:

1. CircleCI now does the `docker build` step instead of letting quay.io do this
1. This was done so that we can run some functional tests pointing Bond at the [mock-provider](https://github.com/broadinstitute/mock-provider)

**Something we'll need to check**
I am not sure how the `latest` tag used to be created by quay.io when it was responsible for building the docker images.  We may need to add a step to push this tag when building the dev branch.


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
