### PR TITLE
move virtualenv instructions up to Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,29 @@
 Service for linking [Sam](https://github.com/broadinstitute/sam) User accounts with registered 3rd party services via
 Oauth2. Bond is a [Google Endpoints](https://cloud.google.com/endpoints/) application written in Python 2.7.
 
-# Dependencies
+# Setup
 
 In order to run tests or run the local development app server, you need to install Python 2.7, Pip, and [Google Cloud SDK](https://cloud.google.com/sdk/install).
+
+## Virtualenv
+
+[Virtualenv](https://virtualenv.pypa.io/en/stable/) is a tool that helps you manage multiple Python versions and your 
+project dependencies.  We recommend you setup Virtualenv for development and testing of Bond.
+
+1. Verify that you have Python 2.7 installed: `python --version`
+(**Note**: The name of your Python 2.7 command may be something different like `python2` if you have multiple versions 
+of Python installed)
+1. Install virtualenv: `pip install virtualenv`
+1. `cd` to the Bond root directory
+1. Set up virtualenv for Bond: `virtualenv -p python env` 
+(**Note**: Ensure that you pass the correct Python 2.7 executable to the [`-p` parameter](https://virtualenv.pypa.io/en/stable/reference/#cmdoption-p)) 
+1. Activate virtualenv: `souce env/bin/activate`
+1. Install project dependencies: `pip install -r requirements.txt -t lib --ignore-installed`
+
+You may now run tests or run the application server normally.
+
+When you are ready to exit or deactivate your Bond virtualenv, just type the command `deactivate` on your command line.
+
 
 # Running Tests
 
@@ -35,25 +55,6 @@ the `tests/integration` directory.
 ## Nose
 * `pip install nose nosegae nose-exclude`
 * ```nosetests --with-gae --gae-lib-root=`gcloud info --format="value(installation.sdk_root)"`/platform/google_appengine --exclude-dir=lib```
-
-# Virtualenv
-
-[Virtualenv](https://virtualenv.pypa.io/en/stable/) is a tool that helps you manage multiple Python versions and your 
-project dependencies.  We recommend you setup Virtualenv for development and testing of Bond.
-
-1. Verify that you have Python 2.7 installed: `python --version`
-(**Note**: The name of your Python 2.7 command may be something different like `python2` if you have multiple versions 
-of Python installed)
-1. Install virtualenv: `pip install virtualenv`
-1. `cd` to the Bond root directory
-1. Set up virtualenv for Bond: `virtualenv -p python env` 
-(**Note**: Ensure that you pass the correct Python 2.7 executable to the [`-p` parameter](https://virtualenv.pypa.io/en/stable/reference/#cmdoption-p)) 
-1. Activate virtualenv: `souce env/bin/activate`
-1. Install project dependencies: `pip install -r requirements.txt -t lib --ignore-installed`
-
-You may now run tests or run the application server normally.
-
-When you are ready to exit or deactivate your Bond virtualenv, just type the command `deactivate` on your command line.
 
 # Running locally
 


### PR DESCRIPTION
Tests did not run without extra setup, so it might make more sense to move this section up so users know to set this up before trying to run tests.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/sam/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
