### PR TITLE
CA-648 Add a wrapper around memcache for easier migration

### DIFF
--- a/cache_api.py
+++ b/cache_api.py
@@ -1,0 +1,74 @@
+import time
+
+class CacheApi:
+    def add(self, key, value, expires_in=0, namespace=None):
+        """
+        Adds the (key, value) to the cache.
+        :param key: A string key
+        :param value: The value to store, retrieved later with 'get.'
+        :param expires_in: The number of seconds to keep the entry before expiration. If zero, never expires.
+        :param namespace: An optional string to further divide the key space.
+        :return: True if added, False on error.
+        """
+        raise NotImplementedError
+
+    def get(self, key, namespace=None):
+        """
+        Retrieves a the value stored by 'add.'
+        :param key: A string key.
+        :param namespace: The namespace used for the 'add' if any.
+        :return: The value of the key if found, else None.
+        """
+        raise NotImplementedError
+
+def create_cache_api():
+    """Create the CacheApi to use in the application."""
+    # TODO(CA-648): Implement an alternative to memcache.
+    # We import memcache_api locally here so that we do not automatically depend on the memcache library. This will make
+    # our migration to python 3, where memcache is not supported.
+    import memcache_api
+    return memcache_api.MemcacheApi()
+
+class LocalCacheApi(CacheApi):
+    """An implementation of CacheApi for testing using in memory dicts."""
+
+    class TimedValue:
+        """An added value and its expiration time in seconds since Unix epoch."""
+        def __init__(self, value, expires_in):
+            """
+            :param value: the added values.
+            :param expires_in: The number of seconds to allow this value before expiring.
+            """
+            self.value = value
+            self.expiration_time = None if expires_in == 0 else time.time() + expires_in
+
+        def get_valid_value(self):
+            """Returns the value if it has not expired, otherwise None. """
+            return self.value if not self.expiration_time or time.time() < self.expiration_time else None
+
+
+    def __init__(self):
+        # Dict for keys with no namespace. Stores TimedValues.
+        self.cache = {}
+        # Dict from namespace to dicts of keys to TimedValues.
+        self.namespaces = {}
+
+    def add(self, key, value, expires_in=0, namespace=None):
+        timed_value = LocalCacheApi.TimedValue(value, expires_in)
+        if namespace:
+            namespace_dict = self.namespaces.setdefault(namespace, {})
+            namespace_dict[key] = timed_value
+        else:
+            self.cache[key] = timed_value
+        return True
+
+    def get(self, key, namespace=None):
+        timed_value = None
+        if namespace:
+            namespace_dict = self.namespaces.get(namespace)
+            if not namespace_dict:
+                return None
+            timed_value = namespace_dict.get(key)
+        else:
+            timed_value = self.cache.get(key)
+        return timed_value.get_valid_value() if timed_value else None

--- a/memcache_api.py
+++ b/memcache_api.py
@@ -1,0 +1,17 @@
+from google.appengine.api import memcache
+
+from cache_api import CacheApi
+
+
+class MemcacheApi(CacheApi):
+    """
+    A wrapper around the memcache library to allow it to be injected as a dependency.
+
+    This allows us to transition to different cache implementations.
+    """
+
+    def add(self, key, value, expires_in=0, namespace=None):
+        return memcache.add(key=key, value=value, time=expires_in, namespace=namespace)
+
+    def get(self, key, namespace=None):
+        return memcache.get(key=key, namespace=namespace)

--- a/status.py
+++ b/status.py
@@ -31,7 +31,7 @@ class Status:
                 self._cache_status(status)
             return status
         except Exception as e:
-            # any exception at this point is the cache cache
+            # any exception at this point is the cache
             return [{"ok": False, "message": e.message, "subsystem": Subsystems.cache}]
 
     def _cache_status(self, status):

--- a/tests/integration/oauth_adapter_test.py
+++ b/tests/integration/oauth_adapter_test.py
@@ -8,6 +8,7 @@ import time
 from google.appengine.ext import testbed
 
 from bond import FenceKeys
+from memcache_api import MemcacheApi
 from jwt_token import JwtToken
 from oauth_adapter import OauthAdapter
 from open_id_config import OpenIdConfig
@@ -35,7 +36,7 @@ class OauthAdapterTestCase(unittest.TestCase):
                 client_id = config.get(section, 'CLIENT_ID')
                 client_secret = config.get(section, 'CLIENT_SECRET')
                 open_id_config_url = config.get(section, 'OPEN_ID_CONFIG_URL')
-                open_id_config = OpenIdConfig(section, open_id_config_url)
+                open_id_config = OpenIdConfig(section, open_id_config_url, MemcacheApi())
                 oauth_adapters[section] = OauthAdapter(client_id, client_secret, open_id_config, section)
         return oauth_adapters
 

--- a/tests/unit/authentication_test.py
+++ b/tests/unit/authentication_test.py
@@ -3,6 +3,7 @@ import unittest
 from google.appengine.api import memcache
 from google.appengine.ext import testbed
 import authentication
+from memcache_api import MemcacheApi
 import json
 import endpoints
 
@@ -23,7 +24,8 @@ class AuthenticationTestCase(unittest.TestCase):
         self.testbed.activate()
         # Next, declare which service stubs you want to use.
         self.testbed.init_memcache_stub()
-        self.auth = authentication.Authentication(authentication.AuthenticationConfig(['32555940559'], ['.gserviceaccount.com'], 600))
+        self.cache_api = MemcacheApi()
+        self.auth = authentication.Authentication(authentication.AuthenticationConfig(['32555940559'], ['.gserviceaccount.com'], 600), self.cache_api)
 
     def tearDown(self):
         self.testbed.deactivate()
@@ -93,7 +95,7 @@ class AuthenticationTestCase(unittest.TestCase):
             self.auth.require_user_info(TestRequestState('bearer ' + token), token_fn2)
 
     def test_good_user_cache_expire_config(self):
-        auth = authentication.Authentication(authentication.AuthenticationConfig(['32555940559'], ['.gserviceaccount.com'], 1))
+        auth = authentication.Authentication(authentication.AuthenticationConfig(['32555940559'], ['.gserviceaccount.com'], 1), self.cache_api)
         token = "testtoken"
         expected_user_info = authentication.UserInfo("193481341723041", "foo@bar.com", token, 100)
 

--- a/tests/unit/bond_test.py
+++ b/tests/unit/bond_test.py
@@ -10,6 +10,7 @@ from google.appengine.ext import testbed
 from mock import MagicMock
 
 from authentication import UserInfo
+from memcache_api import MemcacheApi
 from bond import Bond, FenceKeys
 from fence_api import FenceApi
 from fence_token_vending import FenceTokenVendingMachine
@@ -53,7 +54,7 @@ class BondTestCase(unittest.TestCase):
         self.bond = Bond(mock_oauth_adapter,
                          fence_api,
                          sam_api,
-                         FenceTokenVendingMachine(fence_api, sam_api, mock_oauth_adapter, provider_name),
+                         FenceTokenVendingMachine(fence_api, sam_api, MemcacheApi(), mock_oauth_adapter, provider_name),
                          provider_name,
                          "/context/user/name",
                          {})
@@ -84,7 +85,7 @@ class BondTestCase(unittest.TestCase):
         bond = Bond(mock_oauth_adapter,
                     fence_api,
                     sam_api,
-                    FenceTokenVendingMachine(fence_api, sam_api, mock_oauth_adapter, provider_name),
+                    FenceTokenVendingMachine(fence_api, sam_api, MemcacheApi(), mock_oauth_adapter, provider_name),
                     provider_name,
                     "/context/user/name",
                     {})

--- a/tests/unit/cache_api_test.py
+++ b/tests/unit/cache_api_test.py
@@ -1,0 +1,33 @@
+import time
+import unittest
+
+from cache_api import LocalCacheApi
+
+
+class LocalCacheApiTestCase(unittest.TestCase):
+
+    def test_added_values_retrieved(self):
+        cache = LocalCacheApi()
+        self.assertTrue(cache.add('foo', 42))
+        self.assertTrue(cache.add('bam', 123))
+        self.assertTrue(cache.add('bar', 24, namespace='baz'))
+
+        self.assertEquals(cache.get('foo'), 42)
+        self.assertEquals(cache.get('bam'), 123)
+        self.assertIsNone(cache.get('abc'))
+        self.assertIsNone(cache.get('foo', namespace='baz'))
+
+        self.assertEquals(cache.get('bar', namespace='baz'), 24)
+        self.assertIsNone(cache.get('bar'))
+        self.assertIsNone(cache.get('bar', namespace='qat'))
+
+    def test_expiration(self):
+        cache = LocalCacheApi()
+        self.assertTrue(cache.add('foo', 42, expires_in=0.5))
+        self.assertTrue(cache.add('foo', 24, expires_in=0.5, namespace='bar'))
+
+        self.assertEquals(cache.get('foo'), 42)
+        self.assertEquals(cache.get('foo', namespace='bar'), 24)
+        time.sleep(1)
+        self.assertIsNone(cache.get('foo'))
+        self.assertIsNone(cache.get('foo', namespace='bar'))

--- a/tests/unit/cache_api_test.py
+++ b/tests/unit/cache_api_test.py
@@ -4,30 +4,40 @@ import unittest
 from cache_api import LocalCacheApi
 
 
-class LocalCacheApiTestCase(unittest.TestCase):
+class CacheApiTest(object):
+    """
+    Base class for testing the CacheApi interface.
+    Implementations of CacheApi should subclass this class for testing, calling 'setUpCache' in setUp as needed.
+    """
+
+    def setUpCache(self, cache):
+        self.cache = cache
 
     def test_added_values_retrieved(self):
-        cache = LocalCacheApi()
-        self.assertTrue(cache.add('foo', 42))
-        self.assertTrue(cache.add('bam', 123))
-        self.assertTrue(cache.add('bar', 24, namespace='baz'))
+        self.assertTrue(self.cache.add('foo', 42))
+        self.assertTrue(self.cache.add('bam', 123))
+        self.assertTrue(self.cache.add('bar', 24, namespace='baz'))
 
-        self.assertEquals(cache.get('foo'), 42)
-        self.assertEquals(cache.get('bam'), 123)
-        self.assertIsNone(cache.get('abc'))
-        self.assertIsNone(cache.get('foo', namespace='baz'))
+        self.assertEquals(self.cache.get('foo'), 42)
+        self.assertEquals(self.cache.get('bam'), 123)
+        self.assertIsNone(self.cache.get('abc'))
+        self.assertIsNone(self.cache.get('foo', namespace='baz'))
 
-        self.assertEquals(cache.get('bar', namespace='baz'), 24)
-        self.assertIsNone(cache.get('bar'))
-        self.assertIsNone(cache.get('bar', namespace='qat'))
+        self.assertEquals(self.cache.get('bar', namespace='baz'), 24)
+        self.assertIsNone(self.cache.get('bar'))
+        self.assertIsNone(self.cache.get('bar', namespace='qat'))
 
     def test_expiration(self):
-        cache = LocalCacheApi()
-        self.assertTrue(cache.add('foo', 42, expires_in=0.5))
-        self.assertTrue(cache.add('foo', 24, expires_in=0.5, namespace='bar'))
+        self.assertTrue(self.cache.add('foo', 42, expires_in=0.5))
+        self.assertTrue(self.cache.add('foo', 24, expires_in=0.5, namespace='bar'))
 
-        self.assertEquals(cache.get('foo'), 42)
-        self.assertEquals(cache.get('foo', namespace='bar'), 24)
+        self.assertEquals(self.cache.get('foo'), 42)
+        self.assertEquals(self.cache.get('foo', namespace='bar'), 24)
         time.sleep(1)
-        self.assertIsNone(cache.get('foo'))
-        self.assertIsNone(cache.get('foo', namespace='bar'))
+        self.assertIsNone(self.cache.get('foo'))
+        self.assertIsNone(self.cache.get('foo', namespace='bar'))
+
+
+class LocalCacheApiTestCase(unittest.TestCase, CacheApiTest):
+    def setUp(self):
+        self.setUpCache(LocalCacheApi())

--- a/tests/unit/memcache_api_test.py
+++ b/tests/unit/memcache_api_test.py
@@ -1,0 +1,18 @@
+import unittest
+
+import memcache_api
+from google.appengine.ext import ndb
+from google.appengine.ext import testbed
+from tests.unit import cache_api_test
+
+
+class MemcacheApiTestCase(unittest.TestCase, cache_api_test.CacheApiTest):
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_memcache_stub()
+        self.setUpCache(memcache_api.MemcacheApi())
+
+    def tearDown(self):
+        ndb.get_context().clear_cache()  # Ensure data is truly flushed from memcache
+        self.testbed.deactivate()

--- a/tests/unit/open_id_config_test.py
+++ b/tests/unit/open_id_config_test.py
@@ -1,6 +1,7 @@
 import unittest
 import endpoints
 
+from cache_api import LocalCacheApi
 from mock import MagicMock
 from open_id_config import OpenIdConfig
 
@@ -13,7 +14,7 @@ class OpenIdConfigTestCase(unittest.TestCase):
                        "revocation_endpoint": "",
                        "scopes_supported": ["foo", "bar"]}
         self.provider = "fake_provider"
-        self.open_id_config = OpenIdConfig(self.provider, "not-a-real-url")
+        self.open_id_config = OpenIdConfig(self.provider, "not-a-real-url", LocalCacheApi())
         self.open_id_config.load_dict = MagicMock(return_value=fake_config)
 
     def test_get_config(self):


### PR DESCRIPTION
Add a wrapper around memcache to allow that dependency to be injected.

Also add LocalCacheApi for an in-memory implementation of the add/get memcache API used by Bond. This will help us migrate to a different cache implementation.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
