### PR TITLE
Fix automatic docker integration test

### DIFF
--- a/tests/integration/oauth_adapter_test.py
+++ b/tests/integration/oauth_adapter_test.py
@@ -49,17 +49,21 @@ class OauthAdapterTestCase(unittest.TestCase):
         redirect_uri = "http://local.broadinstitute.org/#fence-callback"
         state = "abc123"
         authz_responses = {}
+        # Whether this test is being run manually or for by automated integration.
+        # The integration run uses a fake provider. The manual run allows testing against real providers with real
+        # authentication. There's not a good way to run integration tests against real providers, so we have this
+        # flag to manually change the tests.
+        manual_run = False
         for provider, oauth_adapter in oauth_adapters.iteritems():
             authz_url = oauth_adapter.build_authz_url(scopes,
                                                       redirect_uri,
                                                       state,
-                                                      extra_authz_url_params={"idp": "google"})
+                                                      extra_authz_url_params={"idp": "google"} if manual_run else {"foo": "bar"})
             print("Please go to %s to authorize access: %s" % (provider, authz_url))
             print("YOU WILL BE REDIRECTED TO %s WHICH WILL PROBABLY UNREACHABLE -- THIS IS EXPECTED!" % redirect_uri)
             print("Please copy/paste the \"code\" parameter from the resulting URL: ")
             sys.stdout.flush()
-            auth_code = sys.stdin.readline().strip()
-            # auth_code = "X"
+            auth_code = sys.stdin.readline().strip() if manual_run else "X"
             authz_responses[provider] = oauth_adapter.exchange_authz_code(auth_code, redirect_uri)
         local_tb.deactivate()
         return authz_responses

--- a/tests/integration/oauth_adapter_test.py
+++ b/tests/integration/oauth_adapter_test.py
@@ -58,7 +58,7 @@ class OauthAdapterTestCase(unittest.TestCase):
             authz_url = oauth_adapter.build_authz_url(scopes,
                                                       redirect_uri,
                                                       state,
-                                                      extra_authz_url_params={"idp": "google"} if manual_run else {"foo": "bar"})
+                                                      extra_authz_url_params={"idp": "google"})
             print("Please go to %s to authorize access: %s" % (provider, authz_url))
             print("YOU WILL BE REDIRECTED TO %s WHICH WILL PROBABLY UNREACHABLE -- THIS IS EXPECTED!" % redirect_uri)
             print("Please copy/paste the \"code\" parameter from the resulting URL: ")


### PR DESCRIPTION
 Revert 65e3a45e6 which allows the test to pass manually in order to run in integration mode by default. Add some comments about what's going on.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
