### PR TITLE
[CA-590] json response verification for integration tests

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -10,3 +10,7 @@ To run the tests from the Bond root directory:
 
 You can optionally specify the environment variable, `BOND_BASE_URL` to specify the host you want to test against.  This
 variable will default to `https://bond-fiab.dsde-dev.broadinstitute.org:31443` unless otherwise specified.
+
+// TODO:  This seems out of date ^ -- 
+`    bond_base_url = "localhost:8080"`
+ 

--- a/automation/README.md
+++ b/automation/README.md
@@ -9,8 +9,6 @@ To run the tests from the Bond root directory:
 `python -m unittest discover -s ./automation/tests -p "*_test.py"`
 
 You can optionally specify the environment variable, `BOND_BASE_URL` to specify the host you want to test against.  This
-variable will default to `https://bond-fiab.dsde-dev.broadinstitute.org:31443` unless otherwise specified.
+variable will default to `https://bond-fiab.dsde-dev.broadinstitute.org:31443` unless otherwise specified. For example:
 
-// TODO:  This seems out of date ^ -- 
-`    bond_base_url = "localhost:8080"`
- 
+`BOND_BASE_URL="localhost:8080" python -m unittest discover -s ./automation/tests -p "*_test.py"`

--- a/automation/helpers/json_responses.py
+++ b/automation/helpers/json_responses.py
@@ -1,5 +1,12 @@
-""" Json Schemas for api_test.py """
+"""
+Json Schemas for api_test.py
 
+Generate, modify, or validate a schema from json here: https://jsonschema.net/
+ """
+
+# todo: clean up these lists -- remove all extraneous fields.
+
+date_regex = "20..-..-..T..:..:.."  #valid through 2099
 
 """Json Schemas for PublicApiTestCase tests"""
 json_schema_test_status = {
@@ -78,34 +85,1067 @@ json_schema_test_list_providers = {
     }
   }
 }
-
-json_schema_test_get_auth_url = {}
-json_schema_test_get_auth_url_without_params = {}
-json_schema_test_get_auth_url_with_only_redirect_param = {}
+json_schema_test_get_auth_url = {
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "url"
+  ],
+  "properties": {
+    "url": {
+      "$id": "#/properties/url",
+      "type": "string",
+      "title": "The Url Schema",
+      "default": "",
+      "examples": [
+        "https://staging.datastage.io/user/oauth2/authorize?response_type=code&client_id=4EmZnWKVMoPyhdJMh7EB8SSl3Uojo20QfsAR77gu&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback&scope=openid+google_credentials&state=eyJmb28iPSJiYXIifQ%3D%3D&idp=fence"
+      ],
+      "pattern": "(https)(.*)(response_type)(.*)(client_id)(.*)(redirect_uri)(.*)(state)(.*)"
+    }
+  }
+}
+json_schema_test_get_auth_url_without_params = {
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "error"
+  ],
+  "properties": {
+    "error": {
+      "$id": "#/properties/error",
+      "type": "object",
+      "title": "The Error Schema",
+      "required": [
+        "code",
+        "errors",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "$id": "#/properties/error/properties/code",
+          "type": "integer",
+          "title": "The Code Schema",
+          "enum": [
+            400
+          ]
+        },
+        "errors": {
+          "$id": "#/properties/error/properties/errors",
+          "type": "array",
+          "title": "The Errors Schema",
+          "items": {
+            "$id": "#/properties/error/properties/errors/items",
+            "type": "object",
+            "title": "The Items Schema",
+            "required": [
+              "domain",
+              "message",
+              "reason"
+            ],
+            "properties": {
+              "domain": {
+                "$id": "#/properties/error/properties/errors/items/properties/domain",
+                "type": "string",
+                "title": "The Domain Schema",
+                "default": "",
+                "enum": [
+                  "global"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "message": {
+                "$id": "#/properties/error/properties/errors/items/properties/message",
+                "type": "string",
+                "title": "The Message Schema",
+                "default": "",
+                "enum": [
+                  "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field redirect_uri)"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "reason": {
+                "$id": "#/properties/error/properties/errors/items/properties/reason",
+                "type": "string",
+                "title": "The Reason Schema",
+                "default": "",
+                "enum": [
+                  "badRequest"
+                ],
+                "pattern": "^(.*)$"
+              }
+            }
+          }
+        },
+        "message": {
+          "$id": "#/properties/error/properties/message",
+          "type": "string",
+          "title": "The Message Schema",
+          "default": "",
+          "enum": [
+            "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field redirect_uri)"
+          ],
+          "pattern": "^(.*)$"
+        }
+      }
+    }
+  }
+}
+json_schema_test_get_auth_url_with_only_redirect_param = json_schema_test_get_auth_url
 
 """Json Schemas for UnlinkedUserTestCase tests"""
-json_schema_test_delete_link_for_unlinked_user = {}
-json_schema_test_get_link_status_for_unlinked_user = {}
-json_schema_test_get_link_status_for_invalid_provider = {}
-json_schema_test_get_access_token_for_unlinked_user = {}
+json_schema_test_delete_link_for_unlinked_user = ""  # Delete call returns an empty body
+json_schema_test_get_link_status_for_unlinked_user = {
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "error"
+  ],
+  "properties": {
+    "error": {
+      "$id": "#/properties/error",
+      "type": "object",
+      "title": "The Error Schema",
+      "required": [
+        "message",
+        "code",
+        "errors"
+      ],
+      "properties": {
+        "message": {
+          "$id": "#/properties/error/properties/message",
+          "type": "string",
+          "title": "The Message Schema",
+          "default": "",
+          "enum": [
+            "fence link does not exist"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "code": {
+          "$id": "#/properties/error/properties/code",
+          "type": "integer",
+          "title": "The Code Schema",
+          "default": 0,
+          "enum": [
+            404
+          ]
+        },
+        "errors": {
+          "$id": "#/properties/error/properties/errors",
+          "type": "array",
+          "title": "The Errors Schema",
+          "items": {
+            "$id": "#/properties/error/properties/errors/items",
+            "type": "object",
+            "title": "The Items Schema",
+            "required": [
+              "reason",
+              "domain",
+              "message"
+            ],
+            "properties": {
+              "reason": {
+                "$id": "#/properties/error/properties/errors/items/properties/reason",
+                "type": "string",
+                "title": "The Reason Schema",
+                "default": "",
+                "enum": [
+                  "notFound"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "domain": {
+                "$id": "#/properties/error/properties/errors/items/properties/domain",
+                "type": "string",
+                "title": "The Domain Schema",
+                "default": "",
+                "enum": [
+                  "global"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "message": {
+                "$id": "#/properties/error/properties/errors/items/properties/message",
+                "type": "string",
+                "title": "The Message Schema",
+                "default": "",
+                "enum": [
+                  "fence link does not exist"
+                ],
+                "pattern": "^(.*)$"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+json_schema_test_get_link_status_for_invalid_provider = {
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "error"
+  ],
+  "properties": {
+    "error": {
+      "$id": "#/properties/error",
+      "type": "object",
+      "title": "The Error Schema",
+      "required": [
+        "message",
+        "code",
+        "errors"
+      ],
+      "properties": {
+        "message": {
+          "$id": "#/properties/error/properties/message",
+          "type": "string",
+          "title": "The Message Schema",
+          "default": "",
+          "enum": [
+            "provider does_not_exist not found"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "code": {
+          "$id": "#/properties/error/properties/code",
+          "type": "integer",
+          "title": "The Code Schema",
+          "default": 0,
+          "enum": [
+            404
+          ]
+        },
+        "errors": {
+          "$id": "#/properties/error/properties/errors",
+          "type": "array",
+          "title": "The Errors Schema",
+          "items": {
+            "$id": "#/properties/error/properties/errors/items",
+            "type": "object",
+            "title": "The Items Schema",
+            "required": [
+              "reason",
+              "domain",
+              "message"
+            ],
+            "properties": {
+              "reason": {
+                "$id": "#/properties/error/properties/errors/items/properties/reason",
+                "type": "string",
+                "title": "The Reason Schema",
+                "default": "",
+                "enum": [
+                  "notFound"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "domain": {
+                "$id": "#/properties/error/properties/errors/items/properties/domain",
+                "type": "string",
+                "title": "The Domain Schema",
+                "default": "",
+                "enum": [
+                  "global"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "message": {
+                "$id": "#/properties/error/properties/errors/items/properties/message",
+                "type": "string",
+                "title": "The Message Schema",
+                "default": "",
+                "enum": [
+                  "provider does_not_exist not found"
+                ],
+                "pattern": "^(.*)$"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+json_schema_test_get_access_token_for_unlinked_user = {
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "error"
+  ],
+  "properties": {
+    "error": {
+      "$id": "#/properties/error",
+      "type": "object",
+      "title": "The Error Schema",
+      "required": [
+        "message",
+        "code",
+        "errors"
+      ],
+      "properties": {
+        "message": {
+          "$id": "#/properties/error/properties/message",
+          "type": "string",
+          "title": "The Message Schema",
+          "default": "",
+          "enum": [
+            "Could not find refresh token for user"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "code": {
+          "$id": "#/properties/error/properties/code",
+          "type": "integer",
+          "title": "The Code Schema",
+          "default": 0,
+          "enum": [
+            400
+          ]
+        },
+        "errors": {
+          "$id": "#/properties/error/properties/errors",
+          "type": "array",
+          "title": "The Errors Schema",
+          "items": {
+            "$id": "#/properties/error/properties/errors/items",
+            "type": "object",
+            "title": "The Items Schema",
+            "required": [
+              "reason",
+              "domain",
+              "message"
+            ],
+            "properties": {
+              "reason": {
+                "$id": "#/properties/error/properties/errors/items/properties/reason",
+                "type": "string",
+                "title": "The Reason Schema",
+                "default": "",
+                "enum": [
+                  "badRequest"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "domain": {
+                "$id": "#/properties/error/properties/errors/items/properties/domain",
+                "type": "string",
+                "title": "The Domain Schema",
+                "default": "",
+                "enum": [
+                  "global"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "message": {
+                "$id": "#/properties/error/properties/errors/items/properties/message",
+                "type": "string",
+                "title": "The Message Schema",
+                "default": "",
+                "enum": [
+                  "Could not find refresh token for user"
+                ],
+                "pattern": "^(.*)$"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
 
 """Json Schemas for ExchangeAuthCodeTestCase tests"""
-json_schema_test_exchange_auth_code = {}
+json_schema_test_exchange_auth_code = {
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "issued_at",
+    "username"
+  ],
+  "properties": {
+    "issued_at": {
+      "$id": "#/properties/issued_at",
+      "type": "string",
+      "title": "The Issued_at Schema",
+      "default": "",
+      "examples": [
+        "2020-01-21T15:17:54"
+      ],
+      "pattern": date_regex
+    },
+    "username": {
+      "$id": "#/properties/username",
+      "type": "string",
+      "title": "The Username Schema",
+      "default": "",
+      "enum": [
+        "jimmyb007"
+      ],
+      "pattern": "^(.*)$"
+    }
+  }
+}
 
 """Json Schemas for ExchangeAuthCodeNegativeTestCase tests"""
-json_schema_test_exchange_auth_code_without_authz_header = {}
-json_schema_test_exchange_auth_code_without_redirect_uri_param = {}
-json_schema_test_exchange_auth_code_without_oauthcode_param = {}
+json_schema_test_exchange_auth_code_without_authz_header = {
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "error"
+  ],
+  "properties": {
+    "error": {
+      "$id": "#/properties/error",
+      "type": "object",
+      "title": "The Error Schema",
+      "required": [
+        "message",
+        "code",
+        "errors"
+      ],
+      "properties": {
+        "message": {
+          "$id": "#/properties/error/properties/message",
+          "type": "string",
+          "title": "The Message Schema",
+          "default": "",
+          "enum": [
+            "Request missing Authorization header."
+          ],
+          "pattern": "^(.*)$"
+        },
+        "code": {
+          "$id": "#/properties/error/properties/code",
+          "type": "integer",
+          "title": "The Code Schema",
+          "default": 0,
+          "enum": [
+            401
+          ]
+        },
+        "errors": {
+          "$id": "#/properties/error/properties/errors",
+          "type": "array",
+          "title": "The Errors Schema",
+          "items": {
+            "$id": "#/properties/error/properties/errors/items",
+            "type": "object",
+            "title": "The Items Schema",
+            "required": [
+              "reason",
+              "domain",
+              "message"
+            ],
+            "properties": {
+              "reason": {
+                "$id": "#/properties/error/properties/errors/items/properties/reason",
+                "type": "string",
+                "title": "The Reason Schema",
+                "default": "",
+                "enum": [
+                  "required"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "domain": {
+                "$id": "#/properties/error/properties/errors/items/properties/domain",
+                "type": "string",
+                "title": "The Domain Schema",
+                "default": "",
+                "enum": [
+                  "global"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "message": {
+                "$id": "#/properties/error/properties/errors/items/properties/message",
+                "type": "string",
+                "title": "The Message Schema",
+                "default": "",
+                "enum": [
+                  "Request missing Authorization header."
+                ],
+                "pattern": "^(.*)$"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+json_schema_test_exchange_auth_code_without_redirect_uri_param = {
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "error"
+  ],
+  "properties": {
+    "error": {
+      "$id": "#/properties/error",
+      "type": "object",
+      "title": "The Error Schema",
+      "required": [
+        "message",
+        "code",
+        "errors"
+      ],
+      "properties": {
+        "message": {
+          "$id": "#/properties/error/properties/message",
+          "type": "string",
+          "title": "The Message Schema",
+          "default": "",
+          "enum": [
+            "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field redirect_uri)"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "code": {
+          "$id": "#/properties/error/properties/code",
+          "type": "integer",
+          "title": "The Code Schema",
+          "default": 0,
+          "enum": [
+            400
+          ]
+        },
+        "errors": {
+          "$id": "#/properties/error/properties/errors",
+          "type": "array",
+          "title": "The Errors Schema",
+          "items": {
+            "$id": "#/properties/error/properties/errors/items",
+            "type": "object",
+            "title": "The Items Schema",
+            "required": [
+              "reason",
+              "domain",
+              "message"
+            ],
+            "properties": {
+              "reason": {
+                "$id": "#/properties/error/properties/errors/items/properties/reason",
+                "type": "string",
+                "title": "The Reason Schema",
+                "default": "",
+                "enum": [
+                  "badRequest"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "domain": {
+                "$id": "#/properties/error/properties/errors/items/properties/domain",
+                "type": "string",
+                "title": "The Domain Schema",
+                "default": "",
+                "enum": [
+                  "global"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "message": {
+                "$id": "#/properties/error/properties/errors/items/properties/message",
+                "type": "string",
+                "title": "The Message Schema",
+                "default": "",
+                "enum": [
+                  "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field redirect_uri)"
+                ],
+                "pattern": "^(.*)$"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+json_schema_test_exchange_auth_code_without_oauthcode_param = {
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "error"
+  ],
+  "properties": {
+    "error": {
+      "$id": "#/properties/error",
+      "type": "object",
+      "title": "The Error Schema",
+      "required": [
+        "message",
+        "code",
+        "errors"
+      ],
+      "properties": {
+        "message": {
+          "$id": "#/properties/error/properties/message",
+          "type": "string",
+          "title": "The Message Schema",
+          "default": "",
+          "enum": [
+            "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field oauthcode)"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "code": {
+          "$id": "#/properties/error/properties/code",
+          "type": "integer",
+          "title": "The Code Schema",
+          "default": 0,
+          "enum": [
+            400
+          ]
+        },
+        "errors": {
+          "$id": "#/properties/error/properties/errors",
+          "type": "array",
+          "title": "The Errors Schema",
+          "items": {
+            "$id": "#/properties/error/properties/errors/items",
+            "type": "object",
+            "title": "The Items Schema",
+            "required": [
+              "reason",
+              "domain",
+              "message"
+            ],
+            "properties": {
+              "reason": {
+                "$id": "#/properties/error/properties/errors/items/properties/reason",
+                "type": "string",
+                "title": "The Reason Schema",
+                "default": "",
+                "enum": [
+                  "badRequest"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "domain": {
+                "$id": "#/properties/error/properties/errors/items/properties/domain",
+                "type": "string",
+                "title": "The Domain Schema",
+                "default": "",
+                "enum": [
+                  "global"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "message": {
+                "$id": "#/properties/error/properties/errors/items/properties/message",
+                "type": "string",
+                "title": "The Message Schema",
+                "default": "",
+                "enum": [
+                  "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field oauthcode)"
+                ],
+                "pattern": "^(.*)$"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
 
 """Json Schemas for LinkedUserTestCase tests"""
-json_schema_test_get_link_status = {}
-json_schema_test_get_access_token = {}
-json_schema_test_get_serviceaccount_key = {}
+json_schema_test_get_link_status = json_schema_test_exchange_auth_code
+json_schema_test_get_access_token = {
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "token",
+    "expires_at"
+  ],
+  "properties": {
+    "token": {
+      "$id": "#/properties/token",
+      "type": "string",
+      "title": "The Token Schema",
+      "default": "",
+      "examples": [
+        "random.string.accesssToken"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "expires_at": {
+      "$id": "#/properties/expires_at",
+      "type": "string",
+      "title": "The Expires_at Schema",
+      "default": "",
+      "examples": [
+        "2020-01-17T22:36:46.479670"
+      ],
+      "pattern": date_regex
+    }
+  }
+}
+json_schema_test_get_serviceaccount_key = {
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "$id": "#/properties/data",
+      "type": "object",
+      "title": "The Data Schema",
+      "required": [
+        "private_key",
+        "private_key_id",
+        "token_uri",
+        "auth_provider_x509_cert_url",
+        "auth_uri",
+        "client_email",
+        "client_id",
+        "project_id",
+        "type",
+        "client_x509_cert_url"
+      ],
+      "properties": {
+        "private_key": {
+          "$id": "#/properties/data/properties/private_key",
+          "type": "string",
+          "title": "The Private_key Schema",
+          "default": "",
+          "examples": [
+            "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhki...KnGMvw==\n-----END PRIVATE KEY-----\n"
+          ],
+          "pattern": "(BEGIN PRIVATE KEY)"
+        },
+        "private_key_id": {
+          "$id": "#/properties/data/properties/private_key_id",
+          "type": "string",
+          "title": "The Private_key_id Schema",
+          "default": "",
+          "examples": [
+            "9d41d414182a8ff73f944ee89d67c605d1821589"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "token_uri": {
+          "$id": "#/properties/data/properties/token_uri",
+          "type": "string",
+          "title": "The Token_uri Schema",
+          "default": "",
+          "examples": [
+            "https://oauth2.googleapis.com/token"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "auth_provider_x509_cert_url": {
+          "$id": "#/properties/data/properties/auth_provider_x509_cert_url",
+          "type": "string",
+          "title": "The Auth_provider_x509_cert_url Schema",
+          "default": "",
+          "examples": [
+            "https://www.googleapis.com/oauth2/v1/certs"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "auth_uri": {
+          "$id": "#/properties/data/properties/auth_uri",
+          "type": "string",
+          "title": "The Auth_uri Schema",
+          "default": "",
+          "examples": [
+            "https://accounts.google.com/o/oauth2/auth"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "client_email": {
+          "$id": "#/properties/data/properties/client_email",
+          "type": "string",
+          "title": "The Client_email Schema",
+          "default": "",
+          "examples": [
+            "mock-provider-user-service-acc@broad-dsde-dev.iam.gserviceaccount.com"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "client_id": {
+          "$id": "#/properties/data/properties/client_id",
+          "type": "string",
+          "title": "The Client_id Schema",
+          "default": "",
+          "examples": [
+            "102327840668511205237"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "project_id": {
+          "$id": "#/properties/data/properties/project_id",
+          "type": "string",
+          "title": "The Project_id Schema",
+          "default": "",
+          "examples": [
+            "broad-dsde-dev"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "type": {
+          "$id": "#/properties/data/properties/type",
+          "type": "string",
+          "title": "The Type Schema",
+          "default": "",
+          "enum": [
+            "service_account"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "client_x509_cert_url": {
+          "$id": "#/properties/data/properties/client_x509_cert_url",
+          "type": "string",
+          "title": "The Client_x509_cert_url Schema",
+          "default": "",
+          "examples": [
+            "https://www.googleapis.com/robot/v1/metadata/x509/mock-provider-user-service-acc%40broad-dsde-dev.iam.gserviceaccount.com"
+          ],
+          "pattern": "^(.*)$"
+        }
+      }
+    }
+  }
+}
 
 """Json Schemas for UnlinkLinkedUserTestCase tests"""
-json_schema_test_delete_link_for_linked_user = {}
-json_schema_test_delete_link_for_invalid_provider = {}
+json_schema_test_delete_link_for_linked_user = ""  # Delete call returns an empty body
+json_schema_test_delete_link_for_invalid_provider = {
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "error"
+  ],
+  "properties": {
+    "error": {
+      "$id": "#/properties/error",
+      "type": "object",
+      "title": "The Error Schema",
+      "required": [
+        "message",
+        "code",
+        "errors"
+      ],
+      "properties": {
+        "message": {
+          "$id": "#/properties/error/properties/message",
+          "type": "string",
+          "title": "The Message Schema",
+          "default": "",
+          "enum": [
+            "provider some-made-up-provider not found"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "code": {
+          "$id": "#/properties/error/properties/code",
+          "type": "integer",
+          "title": "The Code Schema",
+          "default": 0,
+          "enum": [
+            404
+          ]
+        },
+        "errors": {
+          "$id": "#/properties/error/properties/errors",
+          "type": "array",
+          "title": "The Errors Schema",
+          "items": {
+            "$id": "#/properties/error/properties/errors/items",
+            "type": "object",
+            "title": "The Items Schema",
+            "required": [
+              "reason",
+              "domain",
+              "message"
+            ],
+            "properties": {
+              "reason": {
+                "$id": "#/properties/error/properties/errors/items/properties/reason",
+                "type": "string",
+                "title": "The Reason Schema",
+                "default": "",
+                "enum": [
+                  "notFound"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "domain": {
+                "$id": "#/properties/error/properties/errors/items/properties/domain",
+                "type": "string",
+                "title": "The Domain Schema",
+                "default": "",
+                "enum": [
+                  "global"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "message": {
+                "$id": "#/properties/error/properties/errors/items/properties/message",
+                "type": "string",
+                "title": "The Message Schema",
+                "default": "",
+                "enum": [
+                  "provider some-made-up-provider not found"
+                ],
+                "pattern": "^(.*)$"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
 
 """Json Schemas for UserCredentialsTestCase tests"""
-json_schema_test_token = {}
-json_schema_test_user_info_for_delegated_user = {}
+json_schema_test_token = ""  # Creates a token but no API call is made
+json_schema_test_user_info_for_delegated_user = {
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "family_name",
+    "name",
+    "picture",
+    "locale",
+    "email",
+    "given_name",
+    "id",
+    "hd",
+    "verified_email"
+  ],
+  "properties": {
+    "family_name": {
+      "$id": "#/properties/family_name",
+      "type": "string",
+      "title": "The Family_name Schema",
+      "default": "",
+      "enum": [
+        "Granger"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "name": {
+      "$id": "#/properties/name",
+      "type": "string",
+      "title": "The Name Schema",
+      "default": "",
+      "enum": [
+        "Hermione Granger"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "picture": {
+      "$id": "#/properties/picture",
+      "type": "string",
+      "title": "The Picture Schema",
+      "default": "",
+      "enum": [
+        "https://lh3.googleusercontent.com/-vd-xJM0bRSk/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3rc7YyU2qNlHlydOOxp68LcWSB22tw/photo.jpg"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "locale": {
+      "$id": "#/properties/locale",
+      "type": "string",
+      "title": "The Locale Schema",
+      "default": "",
+      "enum": [
+        "en"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "email": {
+      "$id": "#/properties/email",
+      "type": "string",
+      "title": "The Email Schema",
+      "default": "",
+      "enum": [
+        "hermione.owner@test.firecloud.org"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "given_name": {
+      "$id": "#/properties/given_name",
+      "type": "string",
+      "title": "The Given_name Schema",
+      "default": "",
+      "enum": [
+        "Hermione"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "id": {
+      "$id": "#/properties/id",
+      "type": "string",
+      "title": "The Id Schema",
+      "default": "",
+      "enum": [
+        "110530393451290928813"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "hd": {
+      "$id": "#/properties/hd",
+      "type": "string",
+      "title": "The Hd Schema",
+      "default": "",
+      "enum": [
+        "test.firecloud.org"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "verified_email": {
+      "$id": "#/properties/verified_email",
+      "type": "boolean",
+      "title": "The Verified_email Schema",
+      "enum": [
+        True
+      ],
+      "pattern": "^(.*)$"
+    }
+  }
+}

--- a/automation/helpers/json_responses.py
+++ b/automation/helpers/json_responses.py
@@ -6,9 +6,7 @@ Generate, modify, or validate a schema from json here: https://jsonschema.net/
 Use "enum" to ensure exact values.
  """
 
-# todo: clean up these lists -- remove all extraneous fields.
-
-date_regex = "20..-..-..T..:..:.."  #valid through 2099
+DATE_REGEX = "20..-..-..T..:..:.."  #valid through 2099
 
 """Json Schemas for PublicApiTestCase tests"""
 json_schema_test_status = {
@@ -493,7 +491,7 @@ json_schema_test_exchange_auth_code = {
       "examples": [
         "2020-01-21T15:17:54"
       ],
-      "pattern": date_regex
+      "pattern": DATE_REGEX
     },
     "username": {
       "$id": "#/properties/username",
@@ -811,7 +809,7 @@ json_schema_test_get_access_token = {
       "examples": [
         "2020-01-17T22:36:46.479670"
       ],
-      "pattern": date_regex
+      "pattern": DATE_REGEX
     }
   }
 }

--- a/automation/helpers/json_responses.py
+++ b/automation/helpers/json_responses.py
@@ -793,7 +793,7 @@ json_schema_test_user_info_for_delegated_user = {
     },
     "id": {
       "type": "string",
-      "enum": [
+      "example": [
         "110530393451290928813"
       ],
     },

--- a/automation/helpers/json_responses.py
+++ b/automation/helpers/json_responses.py
@@ -23,31 +23,22 @@ json_schema_test_status = {
     },
 }
 json_schema_test_list_providers = {
-  "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "ok",
     "subsystems"
   ],
   "properties": {
     "ok": {
-      "$id": "#/properties/ok",
       "type": "boolean",
-      "title": "The Ok Schema",
       "enum": [True]
     },
     "subsystems": {
-      "$id": "#/properties/subsystems",
       "type": "array",
-      "title": "The Subsystems Schema",
       "items": {
-        "$id": "#/properties/subsystems/items",
         "minItems": 5,
         "type": "object",
-        "title": "The Items Schema",
         "required": [
           "message",
           "ok",
@@ -55,22 +46,14 @@ json_schema_test_list_providers = {
         ],
         "properties": {
           "message": {
-            "$id": "#/properties/subsystems/items/properties/message",
             "type": "string",
-            "title": "The Message Schema",
-            "default": "",
-            "pattern": "^(.*)$"
           },
           "ok": {
-            "$id": "#/properties/subsystems/items/properties/ok",
             "type": "boolean",
-            "title": "The Ok Schema",
             "enum": [True]
           },
           "subsystem": {
-            "$id": "#/properties/subsystems/items/properties/subsystem",
             "type": "string",
-            "title": "The Subsystem Schema",
             "enum": [
               "fence",
               "dcf-fence",
@@ -78,7 +61,6 @@ json_schema_test_list_providers = {
               "datastore",
               "sam"
             ],
-            "pattern": "^(.*)$"
           }
         }
       }
@@ -86,20 +68,14 @@ json_schema_test_list_providers = {
   }
 }
 json_schema_test_get_auth_url = {
-  "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "url"
   ],
   "properties": {
     "url": {
-      "$id": "#/properties/url",
       "type": "string",
-      "title": "The Url Schema",
-      "default": "",
       "examples": [
         "https://staging.datastage.io/user/oauth2/authorize?response_type=code&client_id=4EmZnWKVMoPyhdJMh7EB8SSl3Uojo20QfsAR77gu&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback&scope=openid+google_credentials&state=eyJmb28iPSJiYXIifQ%3D%3D&idp=fence"
       ],
@@ -108,19 +84,14 @@ json_schema_test_get_auth_url = {
   }
 }
 json_schema_test_get_auth_url_without_params = {
-  "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "error"
   ],
   "properties": {
     "error": {
-      "$id": "#/properties/error",
       "type": "object",
-      "title": "The Error Schema",
       "required": [
         "code",
         "errors",
@@ -128,21 +99,15 @@ json_schema_test_get_auth_url_without_params = {
       ],
       "properties": {
         "code": {
-          "$id": "#/properties/error/properties/code",
           "type": "integer",
-          "title": "The Code Schema",
           "enum": [
             400
           ]
         },
         "errors": {
-          "$id": "#/properties/error/properties/errors",
           "type": "array",
-          "title": "The Errors Schema",
           "items": {
-            "$id": "#/properties/error/properties/errors/items",
             "type": "object",
-            "title": "The Items Schema",
             "required": [
               "domain",
               "message",
@@ -150,47 +115,31 @@ json_schema_test_get_auth_url_without_params = {
             ],
             "properties": {
               "domain": {
-                "$id": "#/properties/error/properties/errors/items/properties/domain",
                 "type": "string",
-                "title": "The Domain Schema",
-                "default": "",
                 "enum": [
                   "global"
                 ],
-                "pattern": "^(.*)$"
               },
               "message": {
-                "$id": "#/properties/error/properties/errors/items/properties/message",
                 "type": "string",
-                "title": "The Message Schema",
-                "default": "",
                 "enum": [
                   "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field redirect_uri)"
                 ],
-                "pattern": "^(.*)$"
               },
               "reason": {
-                "$id": "#/properties/error/properties/errors/items/properties/reason",
                 "type": "string",
-                "title": "The Reason Schema",
-                "default": "",
                 "enum": [
                   "badRequest"
                 ],
-                "pattern": "^(.*)$"
               }
             }
           }
         },
         "message": {
-          "$id": "#/properties/error/properties/message",
           "type": "string",
-          "title": "The Message Schema",
-          "default": "",
           "enum": [
             "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field redirect_uri)"
           ],
-          "pattern": "^(.*)$"
         }
       }
     }
@@ -201,19 +150,14 @@ json_schema_test_get_auth_url_with_only_redirect_param = json_schema_test_get_au
 """Json Schemas for UnlinkedUserTestCase tests"""
 json_schema_test_delete_link_for_unlinked_user = ""  # Delete call returns an empty body
 json_schema_test_get_link_status_for_unlinked_user = {
-  "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "error"
   ],
   "properties": {
     "error": {
-      "$id": "#/properties/error",
       "type": "object",
-      "title": "The Error Schema",
       "required": [
         "message",
         "code",
@@ -221,32 +165,22 @@ json_schema_test_get_link_status_for_unlinked_user = {
       ],
       "properties": {
         "message": {
-          "$id": "#/properties/error/properties/message",
           "type": "string",
-          "title": "The Message Schema",
-          "default": "",
           "enum": [
             "fence link does not exist"
           ],
-          "pattern": "^(.*)$"
         },
         "code": {
-          "$id": "#/properties/error/properties/code",
           "type": "integer",
-          "title": "The Code Schema",
           "default": 0,
           "enum": [
             404
           ]
         },
         "errors": {
-          "$id": "#/properties/error/properties/errors",
           "type": "array",
-          "title": "The Errors Schema",
           "items": {
-            "$id": "#/properties/error/properties/errors/items",
             "type": "object",
-            "title": "The Items Schema",
             "required": [
               "reason",
               "domain",
@@ -254,34 +188,22 @@ json_schema_test_get_link_status_for_unlinked_user = {
             ],
             "properties": {
               "reason": {
-                "$id": "#/properties/error/properties/errors/items/properties/reason",
                 "type": "string",
-                "title": "The Reason Schema",
-                "default": "",
                 "enum": [
                   "notFound"
                 ],
-                "pattern": "^(.*)$"
               },
               "domain": {
-                "$id": "#/properties/error/properties/errors/items/properties/domain",
                 "type": "string",
-                "title": "The Domain Schema",
-                "default": "",
                 "enum": [
                   "global"
                 ],
-                "pattern": "^(.*)$"
               },
               "message": {
-                "$id": "#/properties/error/properties/errors/items/properties/message",
                 "type": "string",
-                "title": "The Message Schema",
-                "default": "",
                 "enum": [
                   "fence link does not exist"
                 ],
-                "pattern": "^(.*)$"
               }
             }
           }
@@ -291,19 +213,14 @@ json_schema_test_get_link_status_for_unlinked_user = {
   }
 }
 json_schema_test_get_link_status_for_invalid_provider = {
-  "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "error"
   ],
   "properties": {
     "error": {
-      "$id": "#/properties/error",
       "type": "object",
-      "title": "The Error Schema",
       "required": [
         "message",
         "code",
@@ -311,32 +228,22 @@ json_schema_test_get_link_status_for_invalid_provider = {
       ],
       "properties": {
         "message": {
-          "$id": "#/properties/error/properties/message",
           "type": "string",
-          "title": "The Message Schema",
-          "default": "",
           "enum": [
             "provider does_not_exist not found"
           ],
-          "pattern": "^(.*)$"
         },
         "code": {
-          "$id": "#/properties/error/properties/code",
           "type": "integer",
-          "title": "The Code Schema",
           "default": 0,
           "enum": [
             404
           ]
         },
         "errors": {
-          "$id": "#/properties/error/properties/errors",
           "type": "array",
-          "title": "The Errors Schema",
           "items": {
-            "$id": "#/properties/error/properties/errors/items",
             "type": "object",
-            "title": "The Items Schema",
             "required": [
               "reason",
               "domain",
@@ -344,34 +251,22 @@ json_schema_test_get_link_status_for_invalid_provider = {
             ],
             "properties": {
               "reason": {
-                "$id": "#/properties/error/properties/errors/items/properties/reason",
                 "type": "string",
-                "title": "The Reason Schema",
-                "default": "",
                 "enum": [
                   "notFound"
                 ],
-                "pattern": "^(.*)$"
               },
               "domain": {
-                "$id": "#/properties/error/properties/errors/items/properties/domain",
                 "type": "string",
-                "title": "The Domain Schema",
-                "default": "",
                 "enum": [
                   "global"
                 ],
-                "pattern": "^(.*)$"
               },
               "message": {
-                "$id": "#/properties/error/properties/errors/items/properties/message",
                 "type": "string",
-                "title": "The Message Schema",
-                "default": "",
                 "enum": [
                   "provider does_not_exist not found"
                 ],
-                "pattern": "^(.*)$"
               }
             }
           }
@@ -381,19 +276,14 @@ json_schema_test_get_link_status_for_invalid_provider = {
   }
 }
 json_schema_test_get_access_token_for_unlinked_user = {
-  "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "error"
   ],
   "properties": {
     "error": {
-      "$id": "#/properties/error",
       "type": "object",
-      "title": "The Error Schema",
       "required": [
         "message",
         "code",
@@ -401,32 +291,22 @@ json_schema_test_get_access_token_for_unlinked_user = {
       ],
       "properties": {
         "message": {
-          "$id": "#/properties/error/properties/message",
           "type": "string",
-          "title": "The Message Schema",
-          "default": "",
           "enum": [
             "Could not find refresh token for user"
           ],
-          "pattern": "^(.*)$"
         },
         "code": {
-          "$id": "#/properties/error/properties/code",
           "type": "integer",
-          "title": "The Code Schema",
           "default": 0,
           "enum": [
             400
           ]
         },
         "errors": {
-          "$id": "#/properties/error/properties/errors",
           "type": "array",
-          "title": "The Errors Schema",
           "items": {
-            "$id": "#/properties/error/properties/errors/items",
             "type": "object",
-            "title": "The Items Schema",
             "required": [
               "reason",
               "domain",
@@ -434,34 +314,22 @@ json_schema_test_get_access_token_for_unlinked_user = {
             ],
             "properties": {
               "reason": {
-                "$id": "#/properties/error/properties/errors/items/properties/reason",
                 "type": "string",
-                "title": "The Reason Schema",
-                "default": "",
                 "enum": [
                   "badRequest"
                 ],
-                "pattern": "^(.*)$"
               },
               "domain": {
-                "$id": "#/properties/error/properties/errors/items/properties/domain",
                 "type": "string",
-                "title": "The Domain Schema",
-                "default": "",
                 "enum": [
                   "global"
                 ],
-                "pattern": "^(.*)$"
               },
               "message": {
-                "$id": "#/properties/error/properties/errors/items/properties/message",
                 "type": "string",
-                "title": "The Message Schema",
-                "default": "",
                 "enum": [
                   "Could not find refresh token for user"
                 ],
-                "pattern": "^(.*)$"
               }
             }
           }
@@ -473,54 +341,39 @@ json_schema_test_get_access_token_for_unlinked_user = {
 
 """Json Schemas for ExchangeAuthCodeTestCase tests"""
 json_schema_test_exchange_auth_code = {
-  "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "issued_at",
     "username"
   ],
   "properties": {
     "issued_at": {
-      "$id": "#/properties/issued_at",
       "type": "string",
-      "title": "The Issued_at Schema",
-      "default": "",
       "examples": [
         "2020-01-21T15:17:54"
       ],
       "pattern": DATE_REGEX
     },
     "username": {
-      "$id": "#/properties/username",
       "type": "string",
-      "title": "The Username Schema",
-      "default": "",
       "enum": [
         "jimmyb007"
       ],
-      "pattern": "^(.*)$"
     }
   }
 }
 
 """Json Schemas for ExchangeAuthCodeNegativeTestCase tests"""
 json_schema_test_exchange_auth_code_without_authz_header = {
-  "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "error"
   ],
   "properties": {
     "error": {
-      "$id": "#/properties/error",
       "type": "object",
-      "title": "The Error Schema",
       "required": [
         "message",
         "code",
@@ -528,32 +381,22 @@ json_schema_test_exchange_auth_code_without_authz_header = {
       ],
       "properties": {
         "message": {
-          "$id": "#/properties/error/properties/message",
           "type": "string",
-          "title": "The Message Schema",
-          "default": "",
           "enum": [
             "Request missing Authorization header."
           ],
-          "pattern": "^(.*)$"
         },
         "code": {
-          "$id": "#/properties/error/properties/code",
           "type": "integer",
-          "title": "The Code Schema",
           "default": 0,
           "enum": [
             401
           ]
         },
         "errors": {
-          "$id": "#/properties/error/properties/errors",
           "type": "array",
-          "title": "The Errors Schema",
           "items": {
-            "$id": "#/properties/error/properties/errors/items",
             "type": "object",
-            "title": "The Items Schema",
             "required": [
               "reason",
               "domain",
@@ -561,34 +404,22 @@ json_schema_test_exchange_auth_code_without_authz_header = {
             ],
             "properties": {
               "reason": {
-                "$id": "#/properties/error/properties/errors/items/properties/reason",
                 "type": "string",
-                "title": "The Reason Schema",
-                "default": "",
                 "enum": [
                   "required"
                 ],
-                "pattern": "^(.*)$"
               },
               "domain": {
-                "$id": "#/properties/error/properties/errors/items/properties/domain",
                 "type": "string",
-                "title": "The Domain Schema",
-                "default": "",
                 "enum": [
                   "global"
                 ],
-                "pattern": "^(.*)$"
               },
               "message": {
-                "$id": "#/properties/error/properties/errors/items/properties/message",
                 "type": "string",
-                "title": "The Message Schema",
-                "default": "",
                 "enum": [
                   "Request missing Authorization header."
                 ],
-                "pattern": "^(.*)$"
               }
             }
           }
@@ -598,19 +429,14 @@ json_schema_test_exchange_auth_code_without_authz_header = {
   }
 }
 json_schema_test_exchange_auth_code_without_redirect_uri_param = {
-  "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "error"
   ],
   "properties": {
     "error": {
-      "$id": "#/properties/error",
       "type": "object",
-      "title": "The Error Schema",
       "required": [
         "message",
         "code",
@@ -618,32 +444,22 @@ json_schema_test_exchange_auth_code_without_redirect_uri_param = {
       ],
       "properties": {
         "message": {
-          "$id": "#/properties/error/properties/message",
           "type": "string",
-          "title": "The Message Schema",
-          "default": "",
           "enum": [
             "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field redirect_uri)"
           ],
-          "pattern": "^(.*)$"
         },
         "code": {
-          "$id": "#/properties/error/properties/code",
           "type": "integer",
-          "title": "The Code Schema",
           "default": 0,
           "enum": [
             400
           ]
         },
         "errors": {
-          "$id": "#/properties/error/properties/errors",
           "type": "array",
-          "title": "The Errors Schema",
           "items": {
-            "$id": "#/properties/error/properties/errors/items",
             "type": "object",
-            "title": "The Items Schema",
             "required": [
               "reason",
               "domain",
@@ -651,34 +467,22 @@ json_schema_test_exchange_auth_code_without_redirect_uri_param = {
             ],
             "properties": {
               "reason": {
-                "$id": "#/properties/error/properties/errors/items/properties/reason",
                 "type": "string",
-                "title": "The Reason Schema",
-                "default": "",
                 "enum": [
                   "badRequest"
                 ],
-                "pattern": "^(.*)$"
               },
               "domain": {
-                "$id": "#/properties/error/properties/errors/items/properties/domain",
                 "type": "string",
-                "title": "The Domain Schema",
-                "default": "",
                 "enum": [
                   "global"
                 ],
-                "pattern": "^(.*)$"
               },
               "message": {
-                "$id": "#/properties/error/properties/errors/items/properties/message",
                 "type": "string",
-                "title": "The Message Schema",
-                "default": "",
                 "enum": [
                   "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field redirect_uri)"
                 ],
-                "pattern": "^(.*)$"
               }
             }
           }
@@ -688,19 +492,14 @@ json_schema_test_exchange_auth_code_without_redirect_uri_param = {
   }
 }
 json_schema_test_exchange_auth_code_without_oauthcode_param = {
-  "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "error"
   ],
   "properties": {
     "error": {
-      "$id": "#/properties/error",
       "type": "object",
-      "title": "The Error Schema",
       "required": [
         "message",
         "code",
@@ -708,32 +507,22 @@ json_schema_test_exchange_auth_code_without_oauthcode_param = {
       ],
       "properties": {
         "message": {
-          "$id": "#/properties/error/properties/message",
           "type": "string",
-          "title": "The Message Schema",
-          "default": "",
           "enum": [
             "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field oauthcode)"
           ],
-          "pattern": "^(.*)$"
         },
         "code": {
-          "$id": "#/properties/error/properties/code",
           "type": "integer",
-          "title": "The Code Schema",
           "default": 0,
           "enum": [
             400
           ]
         },
         "errors": {
-          "$id": "#/properties/error/properties/errors",
           "type": "array",
-          "title": "The Errors Schema",
           "items": {
-            "$id": "#/properties/error/properties/errors/items",
             "type": "object",
-            "title": "The Items Schema",
             "required": [
               "reason",
               "domain",
@@ -741,34 +530,22 @@ json_schema_test_exchange_auth_code_without_oauthcode_param = {
             ],
             "properties": {
               "reason": {
-                "$id": "#/properties/error/properties/errors/items/properties/reason",
                 "type": "string",
-                "title": "The Reason Schema",
-                "default": "",
                 "enum": [
                   "badRequest"
                 ],
-                "pattern": "^(.*)$"
               },
               "domain": {
-                "$id": "#/properties/error/properties/errors/items/properties/domain",
                 "type": "string",
-                "title": "The Domain Schema",
-                "default": "",
                 "enum": [
                   "global"
                 ],
-                "pattern": "^(.*)$"
               },
               "message": {
-                "$id": "#/properties/error/properties/errors/items/properties/message",
                 "type": "string",
-                "title": "The Message Schema",
-                "default": "",
                 "enum": [
                   "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field oauthcode)"
                 ],
-                "pattern": "^(.*)$"
               }
             }
           }
@@ -781,31 +558,21 @@ json_schema_test_exchange_auth_code_without_oauthcode_param = {
 """Json Schemas for LinkedUserTestCase tests"""
 json_schema_test_get_link_status = json_schema_test_exchange_auth_code
 json_schema_test_get_access_token = {
-  "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "token",
     "expires_at"
   ],
   "properties": {
     "token": {
-      "$id": "#/properties/token",
       "type": "string",
-      "title": "The Token Schema",
-      "default": "",
       "examples": [
         "random.string.accesssToken"
       ],
-      "pattern": "^(.*)$"
     },
     "expires_at": {
-      "$id": "#/properties/expires_at",
       "type": "string",
-      "title": "The Expires_at Schema",
-      "default": "",
       "examples": [
         "2020-01-17T22:36:46.479670"
       ],
@@ -814,19 +581,14 @@ json_schema_test_get_access_token = {
   }
 }
 json_schema_test_get_serviceaccount_key = {
-  "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "data"
   ],
   "properties": {
     "data": {
-      "$id": "#/properties/data",
       "type": "object",
-      "title": "The Data Schema",
       "required": [
         "private_key",
         "private_key_id",
@@ -841,104 +603,65 @@ json_schema_test_get_serviceaccount_key = {
       ],
       "properties": {
         "private_key": {
-          "$id": "#/properties/data/properties/private_key",
           "type": "string",
-          "title": "The Private_key Schema",
-          "default": "",
           "examples": [
             "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhki...KnGMvw==\n-----END PRIVATE KEY-----\n"
           ],
           "pattern": "(BEGIN PRIVATE KEY)"
         },
         "private_key_id": {
-          "$id": "#/properties/data/properties/private_key_id",
           "type": "string",
-          "title": "The Private_key_id Schema",
-          "default": "",
           "examples": [
             "9d41d414182a8ff73f944ee89d67c605d1821589"
           ],
-          "pattern": "^(.*)$"
         },
         "token_uri": {
-          "$id": "#/properties/data/properties/token_uri",
           "type": "string",
-          "title": "The Token_uri Schema",
-          "default": "",
           "examples": [
             "https://oauth2.googleapis.com/token"
           ],
-          "pattern": "^(.*)$"
         },
         "auth_provider_x509_cert_url": {
-          "$id": "#/properties/data/properties/auth_provider_x509_cert_url",
           "type": "string",
-          "title": "The Auth_provider_x509_cert_url Schema",
-          "default": "",
           "examples": [
             "https://www.googleapis.com/oauth2/v1/certs"
           ],
-          "pattern": "^(.*)$"
         },
         "auth_uri": {
-          "$id": "#/properties/data/properties/auth_uri",
           "type": "string",
-          "title": "The Auth_uri Schema",
-          "default": "",
           "examples": [
             "https://accounts.google.com/o/oauth2/auth"
           ],
-          "pattern": "^(.*)$"
         },
         "client_email": {
-          "$id": "#/properties/data/properties/client_email",
           "type": "string",
-          "title": "The Client_email Schema",
-          "default": "",
           "examples": [
             "mock-provider-user-service-acc@broad-dsde-dev.iam.gserviceaccount.com"
           ],
-          "pattern": "^(.*)$"
         },
         "client_id": {
-          "$id": "#/properties/data/properties/client_id",
           "type": "string",
-          "title": "The Client_id Schema",
-          "default": "",
           "examples": [
             "102327840668511205237"
           ],
-          "pattern": "^(.*)$"
         },
         "project_id": {
-          "$id": "#/properties/data/properties/project_id",
           "type": "string",
-          "title": "The Project_id Schema",
-          "default": "",
           "examples": [
             "broad-dsde-dev"
           ],
-          "pattern": "^(.*)$"
         },
         "type": {
-          "$id": "#/properties/data/properties/type",
           "type": "string",
-          "title": "The Type Schema",
-          "default": "",
           "enum": [
             "service_account"
           ],
-          "pattern": "^(.*)$"
         },
         "client_x509_cert_url": {
-          "$id": "#/properties/data/properties/client_x509_cert_url",
           "type": "string",
-          "title": "The Client_x509_cert_url Schema",
-          "default": "",
           "examples": [
             "https://www.googleapis.com/robot/v1/metadata/x509/mock-provider-user-service-acc%40broad-dsde-dev.iam.gserviceaccount.com"
           ],
-          "pattern": "^(.*)$"
         }
       }
     }
@@ -948,19 +671,14 @@ json_schema_test_get_serviceaccount_key = {
 """Json Schemas for UnlinkLinkedUserTestCase tests"""
 json_schema_test_delete_link_for_linked_user = ""  # Delete call returns an empty body
 json_schema_test_delete_link_for_invalid_provider = {
-  "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "error"
   ],
   "properties": {
     "error": {
-      "$id": "#/properties/error",
       "type": "object",
-      "title": "The Error Schema",
       "required": [
         "message",
         "code",
@@ -968,32 +686,22 @@ json_schema_test_delete_link_for_invalid_provider = {
       ],
       "properties": {
         "message": {
-          "$id": "#/properties/error/properties/message",
           "type": "string",
-          "title": "The Message Schema",
-          "default": "",
           "enum": [
             "provider some-made-up-provider not found"
           ],
-          "pattern": "^(.*)$"
         },
         "code": {
-          "$id": "#/properties/error/properties/code",
           "type": "integer",
-          "title": "The Code Schema",
           "default": 0,
           "enum": [
             404
           ]
         },
         "errors": {
-          "$id": "#/properties/error/properties/errors",
           "type": "array",
-          "title": "The Errors Schema",
           "items": {
-            "$id": "#/properties/error/properties/errors/items",
             "type": "object",
-            "title": "The Items Schema",
             "required": [
               "reason",
               "domain",
@@ -1001,34 +709,22 @@ json_schema_test_delete_link_for_invalid_provider = {
             ],
             "properties": {
               "reason": {
-                "$id": "#/properties/error/properties/errors/items/properties/reason",
                 "type": "string",
-                "title": "The Reason Schema",
-                "default": "",
                 "enum": [
                   "notFound"
                 ],
-                "pattern": "^(.*)$"
               },
               "domain": {
-                "$id": "#/properties/error/properties/errors/items/properties/domain",
                 "type": "string",
-                "title": "The Domain Schema",
-                "default": "",
                 "enum": [
                   "global"
                 ],
-                "pattern": "^(.*)$"
               },
               "message": {
-                "$id": "#/properties/error/properties/errors/items/properties/message",
                 "type": "string",
-                "title": "The Message Schema",
-                "default": "",
                 "enum": [
                   "provider some-made-up-provider not found"
                 ],
-                "pattern": "^(.*)$"
               }
             }
           }
@@ -1041,11 +737,8 @@ json_schema_test_delete_link_for_invalid_provider = {
 """Json Schemas for UserCredentialsTestCase tests"""
 json_schema_test_token = ""  # Creates a token but no API call is made
 json_schema_test_user_info_for_delegated_user = {
-  "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "family_name",
     "name",
@@ -1059,93 +752,58 @@ json_schema_test_user_info_for_delegated_user = {
   ],
   "properties": {
     "family_name": {
-      "$id": "#/properties/family_name",
       "type": "string",
-      "title": "The Family_name Schema",
-      "default": "",
       "enum": [
         "Granger"
       ],
-      "pattern": "^(.*)$"
     },
     "name": {
-      "$id": "#/properties/name",
       "type": "string",
-      "title": "The Name Schema",
-      "default": "",
       "enum": [
         "Hermione Granger"
       ],
-      "pattern": "^(.*)$"
     },
     "picture": {
-      "$id": "#/properties/picture",
       "type": "string",
-      "title": "The Picture Schema",
-      "default": "",
       "enum": [
         "https://lh3.googleusercontent.com/-vd-xJM0bRSk/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3rc7YyU2qNlHlydOOxp68LcWSB22tw/photo.jpg"
       ],
-      "pattern": "^(.*)$"
     },
     "locale": {
-      "$id": "#/properties/locale",
       "type": "string",
-      "title": "The Locale Schema",
-      "default": "",
       "enum": [
         "en"
       ],
-      "pattern": "^(.*)$"
     },
     "email": {
-      "$id": "#/properties/email",
       "type": "string",
-      "title": "The Email Schema",
-      "default": "",
       "enum": [
         "hermione.owner@test.firecloud.org"
       ],
-      "pattern": "^(.*)$"
     },
     "given_name": {
-      "$id": "#/properties/given_name",
       "type": "string",
-      "title": "The Given_name Schema",
-      "default": "",
       "enum": [
         "Hermione"
       ],
-      "pattern": "^(.*)$"
     },
     "id": {
-      "$id": "#/properties/id",
       "type": "string",
-      "title": "The Id Schema",
-      "default": "",
       "enum": [
         "110530393451290928813"
       ],
-      "pattern": "^(.*)$"
     },
     "hd": {
-      "$id": "#/properties/hd",
       "type": "string",
-      "title": "The Hd Schema",
-      "default": "",
       "enum": [
         "test.firecloud.org"
       ],
-      "pattern": "^(.*)$"
     },
     "verified_email": {
-      "$id": "#/properties/verified_email",
       "type": "boolean",
-      "title": "The Verified_email Schema",
       "enum": [
         True
       ],
-      "pattern": "^(.*)$"
     }
   }
 }

--- a/automation/helpers/json_responses.py
+++ b/automation/helpers/json_responses.py
@@ -13,23 +13,6 @@ json_schema_test_status = {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": [
-    "providers"
-  ],
-    "properties": {
-        "providers": {
-            "type": "array",
-            "items": {
-                "type": "string",
-                "minItems": 2,
-                "enum": ["fence", "dcf-fence"]
-            }
-        }
-    },
-}
-json_schema_test_list_providers = {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": [
     "ok",
     "subsystems"
   ],
@@ -70,6 +53,23 @@ json_schema_test_list_providers = {
       }
     }
   }
+}
+json_schema_test_list_providers = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "providers"
+  ],
+    "properties": {
+        "providers": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "minItems": 2,
+                "enum": ["fence", "dcf-fence"]
+            }
+        }
+    },
 }
 json_schema_test_get_auth_url = {
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/automation/helpers/json_responses.py
+++ b/automation/helpers/json_responses.py
@@ -2,6 +2,8 @@
 Json Schemas for api_test.py
 
 Generate, modify, or validate a schema from json here: https://jsonschema.net/
+
+Use "enum" to ensure exact values.
  """
 
 # todo: clean up these lists -- remove all extraneous fields.
@@ -65,7 +67,7 @@ json_schema_test_list_providers = {
             "$id": "#/properties/subsystems/items/properties/ok",
             "type": "boolean",
             "title": "The Ok Schema",
-            "enum": [True]  # todo: add comments to these. or to the top description.
+            "enum": [True]
           },
           "subsystem": {
             "$id": "#/properties/subsystems/items/properties/subsystem",

--- a/automation/helpers/json_responses.py
+++ b/automation/helpers/json_responses.py
@@ -782,8 +782,9 @@ json_schema_test_user_info_for_delegated_user = {
     "email": {
       "type": "string",
       "enum": [
-        "hermione.owner@test.firecloud.org"
-      ],
+        "hermione.owner@test.firecloud.org",
+        "hermione.owner@quality.firecloud.org"
+      ]
     },
     "given_name": {
       "type": "string",
@@ -800,7 +801,8 @@ json_schema_test_user_info_for_delegated_user = {
     "hd": {
       "type": "string",
       "enum": [
-        "test.firecloud.org"
+        "test.firecloud.org",
+        "quality.firecloud.org"
       ],
     },
     "verified_email": {

--- a/automation/helpers/json_responses.py
+++ b/automation/helpers/json_responses.py
@@ -6,7 +6,7 @@ Generate, modify, or validate a schema from json here: https://jsonschema.net/
 Use "enum" to ensure exact values.
  """
 
-DATE_REGEX = "20..-..-..T..:..:.."  #valid through 2099
+DATE_REGEX = "20..-..-..T..:..:.."  # valid through 2099
 
 """Json Schemas for PublicApiTestCase tests"""
 json_schema_test_status = {

--- a/automation/helpers/json_responses.py
+++ b/automation/helpers/json_responses.py
@@ -769,7 +769,7 @@ json_schema_test_user_info_for_delegated_user = {
     },
     "picture": {
       "type": "string",
-      "enum": [
+      "example": [
         "https://lh3.googleusercontent.com/-vd-xJM0bRSk/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3rc7YyU2qNlHlydOOxp68LcWSB22tw/photo.jpg"
       ],
     },

--- a/automation/helpers/json_responses.py
+++ b/automation/helpers/json_responses.py
@@ -3,14 +3,18 @@ Json Schemas for api_test.py
 
 Generate, modify, or validate a schema from json here: https://jsonschema.net/
 
-Use "enum" to ensure exact values.
+Use "enum" to ensure exact values. Remove superfluous fields.
  """
 
 DATE_REGEX = "20..-..-..T..:..:.."  # valid through 2099
 
 """Json Schemas for PublicApiTestCase tests"""
 json_schema_test_status = {
-    "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "providers"
+  ],
     "properties": {
         "providers": {
             "type": "array",

--- a/automation/helpers/json_responses.py
+++ b/automation/helpers/json_responses.py
@@ -1,0 +1,111 @@
+""" Json Schemas for api_test.py """
+
+
+"""Json Schemas for PublicApiTestCase tests"""
+json_schema_test_status = {
+    "type": "object",
+    "properties": {
+        "providers": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "minItems": 2,
+                "enum": ["fence", "dcf-fence"]
+            }
+        }
+    },
+}
+json_schema_test_list_providers = {
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "ok",
+    "subsystems"
+  ],
+  "properties": {
+    "ok": {
+      "$id": "#/properties/ok",
+      "type": "boolean",
+      "title": "The Ok Schema",
+      "enum": [True]
+    },
+    "subsystems": {
+      "$id": "#/properties/subsystems",
+      "type": "array",
+      "title": "The Subsystems Schema",
+      "items": {
+        "$id": "#/properties/subsystems/items",
+        "minItems": 5,
+        "type": "object",
+        "title": "The Items Schema",
+        "required": [
+          "message",
+          "ok",
+          "subsystem"
+        ],
+        "properties": {
+          "message": {
+            "$id": "#/properties/subsystems/items/properties/message",
+            "type": "string",
+            "title": "The Message Schema",
+            "default": "",
+            "pattern": "^(.*)$"
+          },
+          "ok": {
+            "$id": "#/properties/subsystems/items/properties/ok",
+            "type": "boolean",
+            "title": "The Ok Schema",
+            "enum": [True]  # todo: add comments to these. or to the top description.
+          },
+          "subsystem": {
+            "$id": "#/properties/subsystems/items/properties/subsystem",
+            "type": "string",
+            "title": "The Subsystem Schema",
+            "enum": [
+              "fence",
+              "dcf-fence",
+              "memcache",
+              "datastore",
+              "sam"
+            ],
+            "pattern": "^(.*)$"
+          }
+        }
+      }
+    }
+  }
+}
+
+json_schema_test_get_auth_url = {}
+json_schema_test_get_auth_url_without_params = {}
+json_schema_test_get_auth_url_with_only_redirect_param = {}
+
+"""Json Schemas for UnlinkedUserTestCase tests"""
+json_schema_test_delete_link_for_unlinked_user = {}
+json_schema_test_get_link_status_for_unlinked_user = {}
+json_schema_test_get_link_status_for_invalid_provider = {}
+json_schema_test_get_access_token_for_unlinked_user = {}
+
+"""Json Schemas for ExchangeAuthCodeTestCase tests"""
+json_schema_test_exchange_auth_code = {}
+
+"""Json Schemas for ExchangeAuthCodeNegativeTestCase tests"""
+json_schema_test_exchange_auth_code_without_authz_header = {}
+json_schema_test_exchange_auth_code_without_redirect_uri_param = {}
+json_schema_test_exchange_auth_code_without_oauthcode_param = {}
+
+"""Json Schemas for LinkedUserTestCase tests"""
+json_schema_test_get_link_status = {}
+json_schema_test_get_access_token = {}
+json_schema_test_get_serviceaccount_key = {}
+
+"""Json Schemas for UnlinkLinkedUserTestCase tests"""
+json_schema_test_delete_link_for_linked_user = {}
+json_schema_test_delete_link_for_invalid_provider = {}
+
+"""Json Schemas for UserCredentialsTestCase tests"""
+json_schema_test_token = {}
+json_schema_test_user_info_for_delegated_user = {}

--- a/automation/tests/api_test.py
+++ b/automation/tests/api_test.py
@@ -187,6 +187,9 @@ class LinkedUserTestCase(AuthorizedBaseCase):
     def tearDownClass(cls):
         cls.unlink(cls.token)
 
+    # The lack of a fence testing environment (See: https://broadworkbench.atlassian.net/browse/CA-303) is preventing
+    #  4 test cases from running as integration tests - the 3 below as well as test_exchange_auth_code. We are running
+    #  these tests against mocks due to this.
     def test_get_link_status(self):
         url = self.bond_base_url + "/api/link/v1/" + self.provider
         r = requests.get(url, headers=self.bearer_token_header(LinkedUserTestCase.token))

--- a/automation/tests/api_test.py
+++ b/automation/tests/api_test.py
@@ -11,7 +11,6 @@ from automation.helpers.json_responses import *
 class BaseApiTestCase(unittest.TestCase):
     env = os.getenv("ENV", "dev")
     bond_base_url = "https://bond-fiab.dsde-%s.broadinstitute.org:31443" % env
-    # bond_base_url = "http://localhost:8080" # put this back -- to be fixed in Marc's PR.
     provider = "fence"
     email_domain = "quality.firecloud.org" if (env == "qa") else "test.firecloud.org"
 

--- a/automation/tests/api_test.py
+++ b/automation/tests/api_test.py
@@ -25,7 +25,7 @@ class PublicApiTestCase(BaseApiTestCase):
         self.assertEqual(200, r.status_code)
         response_json_dict = json.loads(r.text)  # sorted??
         self.assertTrue(response_json_dict['ok'])
-        validate(instance=response_json_dict, schema=json_schema_test_list_providers)
+        validate(instance=response_json_dict, schema=json_schema_test_status)
 
     def test_list_providers(self):
         url = self.bond_base_url + "/api/link/v1/providers"
@@ -33,7 +33,7 @@ class PublicApiTestCase(BaseApiTestCase):
         self.assertEqual(200, r.status_code)
         response_json_dict = json.loads(r.text)
         self.assertIsNotNone(response_json_dict["providers"])
-        validate(instance=response_json_dict, schema=json_schema_test_status)
+        validate(instance=response_json_dict, schema=json_schema_test_list_providers)
 
     def test_get_auth_url(self):
         url = self.bond_base_url + "/api/link/v1/" + self.provider + "/authorization-url" + "?scopes=openid&scopes=google_credentials&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback&state=eyJmb28iPSJiYXIifQ=="

--- a/automation/tests/api_test.py
+++ b/automation/tests/api_test.py
@@ -23,8 +23,7 @@ class PublicApiTestCase(BaseApiTestCase):
         url = self.bond_base_url + "/api/status/v1/status"
         r = requests.get(url)
         self.assertEqual(200, r.status_code)
-        response_json_dict = json.loads(r.text)  # sorted??
-        self.assertTrue(response_json_dict['ok'])
+        response_json_dict = json.loads(r.text)
         validate(instance=response_json_dict, schema=json_schema_test_status)
 
     def test_list_providers(self):
@@ -32,7 +31,6 @@ class PublicApiTestCase(BaseApiTestCase):
         r = requests.get(url)
         self.assertEqual(200, r.status_code)
         response_json_dict = json.loads(r.text)
-        self.assertIsNotNone(response_json_dict["providers"])
         validate(instance=response_json_dict, schema=json_schema_test_list_providers)
 
     def test_get_auth_url(self):
@@ -40,14 +38,6 @@ class PublicApiTestCase(BaseApiTestCase):
         r = requests.get(url)
         self.assertEqual(200, r.status_code)
         response_json_dict = json.loads(r.text)
-        authz_url = urlparse.urlparse(response_json_dict["url"])
-        query_params = urlparse.parse_qs(authz_url.query)
-        self.assertEqual("https", authz_url.scheme)
-        self.assertIsNotNone(authz_url.netloc)
-        self.assertIsNotNone(query_params["redirect_uri"])
-        self.assertIsNotNone(query_params["response_type"])
-        self.assertIsNotNone(query_params["client_id"])
-        self.assertIsNotNone(query_params["state"])
         validate(instance=response_json_dict, schema=json_schema_test_get_auth_url)
 
     def test_get_auth_url_without_params(self):
@@ -62,12 +52,6 @@ class PublicApiTestCase(BaseApiTestCase):
         r = requests.get(url)
         self.assertEqual(200, r.status_code)
         response_json_dict = json.loads(r.text)
-        authz_url = urlparse.urlparse(response_json_dict["url"])
-        query_params = urlparse.parse_qs(authz_url.query)
-        self.assertIsNotNone(query_params["redirect_uri"])
-        self.assertIsNotNone(query_params["response_type"])
-        self.assertIsNotNone(query_params["client_id"])
-        self.assertIsNotNone(query_params["state"])
         validate(instance=response_json_dict, schema=json_schema_test_get_auth_url_with_only_redirect_param)
 
 
@@ -123,15 +107,15 @@ class UnlinkedUserTestCase(AuthorizedUnlinkedUser):
     def test_get_link_status_for_unlinked_user(self):
         url = self.bond_base_url + "/api/link/v1/" + self.provider
         r = requests.get(url, headers=self.bearer_token_header(self.token))
-        response_json_dict = json.loads(r.text)
         self.assertEqual(404, r.status_code)
+        response_json_dict = json.loads(r.text)
         validate(instance=response_json_dict, schema=json_schema_test_get_link_status_for_unlinked_user)
 
     def test_get_link_status_for_invalid_provider(self):
         url = self.bond_base_url + "/api/link/v1/" + "does_not_exist"
         r = requests.get(url, headers=self.bearer_token_header(self.token))
-        response_json_dict = json.loads(r.text)
         self.assertEqual(404, r.status_code)
+        response_json_dict = json.loads(r.text)
         validate(instance=response_json_dict, schema=json_schema_test_get_link_status_for_invalid_provider)
 
     def test_get_access_token_for_unlinked_user(self):
@@ -150,8 +134,6 @@ class ExchangeAuthCodeTestCase(AuthorizedUnlinkedUser):
         r = requests.post(url, headers=self.bearer_token_header(self.token))
         self.assertEqual(200, r.status_code, "Response code was not 200.  Response Body: %s" % r.text)
         response_json_dict = json.loads(r.text)
-        self.assertIsNotNone(response_json_dict["issued_at"])
-        self.assertIsNotNone(response_json_dict["username"])
         validate(instance=response_json_dict, schema=json_schema_test_exchange_auth_code)
 
 
@@ -213,8 +195,6 @@ class LinkedUserTestCase(AuthorizedBaseCase):
         r = requests.get(url, headers=self.bearer_token_header(LinkedUserTestCase.token))
         self.assertEqual(200, r.status_code, "Response code was not 200.  Response Body: %s" % r.text)
         response_json_dict = json.loads(r.text)
-        self.assertIsNotNone(response_json_dict["expires_at"])
-        self.assertIsNotNone(response_json_dict["token"])
         validate(instance=response_json_dict, schema=json_schema_test_get_access_token)
 
     def test_get_serviceaccount_key(self):
@@ -222,10 +202,6 @@ class LinkedUserTestCase(AuthorizedBaseCase):
         r = requests.get(url, headers=self.bearer_token_header(LinkedUserTestCase.token))
         self.assertEqual(200, r.status_code, "Response code was not 200.  Response Body: %s" % r.text)
         response_json_dict = json.loads(r.text)
-        # We could assert that more elements are present here in the result, but we are basically just verifying the
-        # structure of a Google Service Account Key, which is probably not something we should test here
-        self.assertIsNotNone(response_json_dict["data"]["private_key"])
-        self.assertEqual("service_account", response_json_dict["data"]["type"])
         validate(instance=response_json_dict, schema=json_schema_test_get_serviceaccount_key)
 
 
@@ -264,7 +240,5 @@ class UserCredentialsTestCase(AuthorizedBaseCase):
     def test_user_info_for_delegated_user(self):
         r = requests.get("https://www.googleapis.com/oauth2/v1/userinfo?alt=json",
                          headers=self.bearer_token_header(self.token))
-        user_info = json.loads(r.text)
-        self.assertEqual(self.hermione_email, user_info["email"])
         response_json_dict = json.loads(r.text)
         validate(instance=response_json_dict, schema=json_schema_test_user_info_for_delegated_user)

--- a/automation/tests/api_test.py
+++ b/automation/tests/api_test.py
@@ -10,7 +10,8 @@ from automation.helpers.json_responses import *
 
 class BaseApiTestCase(unittest.TestCase):
     env = os.getenv("ENV", "dev")
-    bond_base_url = "https://bond-fiab.dsde-%s.broadinstitute.org:31443" % env
+    # bond_base_url = "https://bond-fiab.dsde-%s.broadinstitute.org:31443" % env
+    bond_base_url = "http://localhost:8080"
     provider = "fence"
     email_domain = "quality.firecloud.org" if (env == "qa") else "test.firecloud.org"
 

--- a/automation/tests/api_test.py
+++ b/automation/tests/api_test.py
@@ -10,8 +10,8 @@ from automation.helpers.json_responses import *
 
 class BaseApiTestCase(unittest.TestCase):
     env = os.getenv("ENV", "dev")
-    # bond_base_url = "https://bond-fiab.dsde-%s.broadinstitute.org:31443" % env
-    bond_base_url = "http://localhost:8080"
+    bond_base_url = "https://bond-fiab.dsde-%s.broadinstitute.org:31443" % env
+    # bond_base_url = "http://localhost:8080" # put this back -- to be fixed in Marc's PR.
     provider = "fence"
     email_domain = "quality.firecloud.org" if (env == "qa") else "test.firecloud.org"
 
@@ -48,7 +48,7 @@ class PublicApiTestCase(BaseApiTestCase):
         self.assertIsNotNone(query_params["response_type"])
         self.assertIsNotNone(query_params["client_id"])
         self.assertIsNotNone(query_params["state"])
-        validate(instance=response_json_dict, schema=json_schema_test_get_auth_url)  #todo: check for ONLY the query params in the regex
+        validate(instance=response_json_dict, schema=json_schema_test_get_auth_url)
 
     def test_get_auth_url_without_params(self):
         url = self.bond_base_url + "/api/link/v1/" + self.provider + "/authorization-url"
@@ -154,7 +154,6 @@ class ExchangeAuthCodeTestCase(AuthorizedUnlinkedUser):
         self.assertIsNotNone(response_json_dict["username"])
         validate(instance=response_json_dict, schema=json_schema_test_exchange_auth_code)
 
-## TODO: try crashing bond again locally by making all these fail.
 
 class ExchangeAuthCodeNegativeTestCase(AuthorizedUnlinkedUser):
     """

--- a/automation/tests/api_test.py
+++ b/automation/tests/api_test.py
@@ -1,8 +1,6 @@
-import collections
 import json
 import unittest
 import requests
-import urlparse
 import os
 from automation.helpers.user_credentials import UserCredentials
 from jsonschema import validate

--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -3,7 +3,7 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 {{with $secrets := secret (printf "secret/dsde/bond/%s/config.ini" $environment)}}
 
-{{if eq $runContext "fiab"}}
+{{if (or (eq $runContext "fiab") (eq $runContext "local")) }}
 # fiab settings are mock providers
 
 [fence]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+jsonschema
 google-endpoints==4.6.1
 google-endpoints-api-management==1.11.0
 requests==2.20.0


### PR DESCRIPTION
\<your comments for this PR go here\>

This PR:
addresses: https://broadworkbench.atlassian.net/browse/CA-590 to create robust tests to validate API json responses return the same data between releases and especially for the python2->3 migration/upgrade.

and adds:
- json verification using Json Schema ([reasoning for this is here](https://github.com/DataBiosphere/bond/pull/92/commits/268ebbc5d9ce7a5f5346d1244a92974dd743ceb5)). Any feedback on organizing the json schema would be especially appreciated.
- mock config for local envs

and removes:
- now-duplicated test code


Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
