### PR TITLE
CA-648 Add a Datastore backed implementation of CacheApi.

### DIFF
--- a/datastore_cache_api.py
+++ b/datastore_cache_api.py
@@ -1,0 +1,62 @@
+import datetime
+from google.appengine.ext import ndb
+from cache_api import CacheApi
+import logging
+
+_NO_EXPIRATION_DATETIME = datetime.datetime(year=3000, month=1, day=1)
+
+
+class CacheEntry(ndb.Model):
+    """Datastore model for cache values and expirations."""
+    # The value stored in the cache.
+    value = ndb.PickleProperty()
+    # The datetime when to expire the cache entry, or _NO_EXPIRATION_DATETIME for no expiration.
+    # Datastore docs warn against doing this at high write rates.
+    # https://cloud.google.com/datastore/docs/best-practices#deletions
+    expires_at = ndb.DateTimeProperty()
+
+
+class DatastoreCacheApi(CacheApi):
+    """
+    A CacheApi backed by Datastore.
+
+    N.B. expiration does not happen automatically. In appengine we use a cron.yml to ensure that we periodically
+    delete expired entries.
+    """
+
+    def add(self, key, value, expires_in=0, namespace=None):
+        CacheEntry(key=DatastoreCacheApi._build_cache_key(key, namespace), value=value,
+                   expires_at=DatastoreCacheApi._calculate_expiration(expires_in)).put()
+        return True
+
+    def get(self, key, namespace=None):
+        entry = DatastoreCacheApi._build_cache_key(key, namespace).get()
+        if not entry or entry.expires_at < datetime.datetime.now():
+            return None
+        return entry.value
+
+    @staticmethod
+    def delete_expired_entries():
+        """Deletes the entries that have expired. This must be done periodically. """
+        expired_entries = CacheEntry.query(CacheEntry.expires_at < datetime.datetime.now())
+        deletions = ndb.delete_multi([key for key in expired_entries.iter(keys_only=True)])
+        logging.info("Deleted %d cache entries.", len(deletions))
+
+    @staticmethod
+    def _build_cache_key(key, namespace):
+        """Create an ndb Key for the key and namespace."""
+        if namespace is not None:
+            return ndb.Key("cache namespace", namespace, CacheEntry, key)
+        else:
+            return ndb.Key(CacheEntry, key)
+
+    @staticmethod
+    def _calculate_expiration(expires_in):
+        """
+        Calculates the datetime that an entry should expire.
+        :param expires_in in how many seconds to expire the key, or 0 if it should not expire.
+        :return: The expiration datetime or else None if it should not expire.
+        """
+        if expires_in == 0:
+            return _NO_EXPIRATION_DATETIME
+        return datetime.datetime.now() + datetime.timedelta(seconds=expires_in)

--- a/tests/unit/datastore_cache_api_test.py
+++ b/tests/unit/datastore_cache_api_test.py
@@ -11,6 +11,7 @@ class DatstoreCacheApiTestCase(unittest.TestCase, cache_api_test.CacheApiTest):
     def setUp(self):
         self.testbed = testbed.Testbed()
         self.testbed.activate()
+        # Datastore uses memcache by default.
         self.testbed.init_memcache_stub()
         self.testbed.init_datastore_v3_stub()
         self.setUpCache(DatastoreCacheApi())

--- a/tests/unit/datastore_cache_api_test.py
+++ b/tests/unit/datastore_cache_api_test.py
@@ -1,0 +1,44 @@
+import time
+import unittest
+
+from datastore_cache_api import DatastoreCacheApi
+from google.appengine.ext import ndb
+from google.appengine.ext import testbed
+from tests.unit import cache_api_test
+
+
+class DatstoreCacheApiTestCase(unittest.TestCase, cache_api_test.CacheApiTest):
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_memcache_stub()
+        self.testbed.init_datastore_v3_stub()
+        self.setUpCache(DatastoreCacheApi())
+
+    def tearDown(self):
+        ndb.get_context().clear_cache()  # Ensure data is truly flushed from memcache
+        self.testbed.deactivate()
+
+    def test_delete_removes_expired_entries(self):
+        cache = DatastoreCacheApi()
+
+        cache.add("foo", "foo_value", expires_in=0.5)
+        cache.add("foo_namespace", "foo_namespace_value", expires_in=0.5, namespace="baz")
+        cache.add("not_expired", "not_expired_value", expires_in=100)
+        cache.add("no_expiration", "no_expiration_value")
+
+        foo_key = DatastoreCacheApi._build_cache_key("foo", None)
+        self.assertIsNotNone(foo_key.get())
+
+        time.sleep(1)
+
+        # Value expired, but entry is still present in Datastore.
+        self.assertIsNone(cache.get("foo"))
+        self.assertIsNotNone(foo_key.get())
+
+        cache.delete_expired_entries()
+
+        self.assertIsNone(foo_key.get())
+        self.assertIsNone(DatastoreCacheApi._build_cache_key("foo_namespace", "baz").get())
+        self.assertIsNotNone(DatastoreCacheApi._build_cache_key("not_expired", None).get())
+        self.assertIsNotNone(DatastoreCacheApi._build_cache_key("no_expiration", None).get())


### PR DESCRIPTION
To be used to replace memcache implementation. Also needs work to expose an endpoint to hit with a cron to periodically delete expired entries.

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [ ] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
