### PR TITLE
Fix automation tests/jenkins status breakage

### DIFF
--- a/automation/helpers/json_responses.py
+++ b/automation/helpers/json_responses.py
@@ -44,7 +44,7 @@ json_schema_test_status = {
             "enum": [
               "fence",
               "dcf-fence",
-              "memcache",
+              "cache",
               "datastore",
               "sam"
             ],


### PR DESCRIPTION
Broken by different branches coming into develop modifying the status being returned and asserting what status was being returned. See PRs #86 & #92.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
