### PR TITLE
[CA-592] Throw JSON exceptions instead of HTML ones

### DIFF
--- a/automation/helpers/json_responses.py
+++ b/automation/helpers/json_responses.py
@@ -44,7 +44,7 @@ json_schema_test_status = {
             "enum": [
               "fence",
               "dcf-fence",
-              "memcache",
+              "cache",
               "datastore",
               "sam"
             ],
@@ -127,7 +127,7 @@ json_schema_test_get_auth_url_without_params = {
               "message": {
                 "type": "string",
                 "enum": [
-                  "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field redirect_uri)"
+                  "The browser (or proxy) sent a request that this server could not understand."
                 ],
               },
               "reason": {
@@ -142,7 +142,7 @@ json_schema_test_get_auth_url_without_params = {
         "message": {
           "type": "string",
           "enum": [
-            "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field redirect_uri)"
+            "The browser (or proxy) sent a request that this server could not understand."
           ],
         }
       }
@@ -450,7 +450,7 @@ json_schema_test_exchange_auth_code_without_redirect_uri_param = {
         "message": {
           "type": "string",
           "enum": [
-            "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field redirect_uri)"
+            "The browser (or proxy) sent a request that this server could not understand."
           ],
         },
         "code": {
@@ -485,7 +485,7 @@ json_schema_test_exchange_auth_code_without_redirect_uri_param = {
               "message": {
                 "type": "string",
                 "enum": [
-                  "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field redirect_uri)"
+                  "The browser (or proxy) sent a request that this server could not understand."
                 ],
               }
             }
@@ -513,7 +513,7 @@ json_schema_test_exchange_auth_code_without_oauthcode_param = {
         "message": {
           "type": "string",
           "enum": [
-            "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field oauthcode)"
+            "The browser (or proxy) sent a request that this server could not understand."
           ],
         },
         "code": {
@@ -548,7 +548,7 @@ json_schema_test_exchange_auth_code_without_oauthcode_param = {
               "message": {
                 "type": "string",
                 "enum": [
-                  "Error parsing ProtoRPC request (Unable to parse request content: Message CombinedContainer is missing required field oauthcode)"
+                  "The browser (or proxy) sent a request that this server could not understand."
                 ],
               }
             }

--- a/json_exception_handler.py
+++ b/json_exception_handler.py
@@ -8,7 +8,7 @@ class JsonExceptionHandler(object):
             self.init_app(app)
 
     def json_dict(self, status_code, message):
-        exception_reasons = {400: "badRequest", 401: "required", 404: "notFound"}
+        exception_reasons = {400: "badRequest", 401: "required", 404: "notFound", 500: "internalServerError"}
         return {"code": status_code,
                 "errors": [{
                     "domain": "global",

--- a/json_exception_handler.py
+++ b/json_exception_handler.py
@@ -8,12 +8,16 @@ class JsonExceptionHandler(object):
             self.init_app(app)
 
     def json_dict(self, status_code, message):
-        exception_reasons = {400: "badRequest", 401: "required", 404: "notFound", 500: "internalServerError"}
+        exception_reasons = {400: "badRequest",
+                             401: "required",
+                             403: "forbidden",
+                             404: "notFound",
+                             500: "internalServerError"}
         return {"code": status_code,
                 "errors": [{
                     "domain": "global",
                     "message": message,
-                    "reason": exception_reasons[status_code]
+                    "reason": exception_reasons[status_code] if status_code in exception_reasons.keys() else ""
                 }],
                 "message": message}
 

--- a/json_exception_handler.py
+++ b/json_exception_handler.py
@@ -1,0 +1,36 @@
+from flask import jsonify
+from werkzeug import exceptions
+
+
+class JsonExceptionHandler(object):
+    def __init__(self, app=None):
+        if app:
+            self.init_app(app)
+
+    def json_dict(self, status_code, message):
+        exception_reasons = {400: "badRequest", 401: "required", 404: "notFound"}
+        return {"code": status_code,
+                "errors": [{
+                    "domain": "global",
+                    "message": message,
+                    "reason": exception_reasons[status_code]
+                }],
+                "message": message}
+
+    def std_handler(self, error):
+        if isinstance(error, exceptions.HTTPException):
+            response = jsonify(error=self.json_dict(error.code, error.description))
+            response.status_code = error.code
+        else:
+            response = jsonify(error=str(error))
+            response.status_code = 500
+        return response
+
+    def init_app(self, app):
+        self.app = app
+        self.register(exceptions.HTTPException)
+        for code, v in exceptions.default_exceptions.iteritems():
+            self.register(code)
+
+    def register(self, exception_or_code, handler=None):
+        self.app.errorhandler(exception_or_code)(handler or self.std_handler)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import flask
 import routes
+from json_exception_handler import JsonExceptionHandler
 
 
 def create_app():
@@ -10,3 +11,4 @@ def create_app():
 
 
 app = create_app()
+handler = JsonExceptionHandler(app)

--- a/routes.py
+++ b/routes.py
@@ -105,7 +105,6 @@ def create_provider(provider_name):
                                         fence_tvm,
                                         provider_name,
                                         user_name_path_expr,
-
                                         extra_authz_url_params))
 
 

--- a/routes.py
+++ b/routes.py
@@ -97,7 +97,7 @@ def create_provider(provider_name):
     sam_api = SamApi(sam_base_url)
 
     fence_tvm = FenceTokenVendingMachine(fence_api, sam_api, cache_api, refresh_token_store, oauth_adapter,
-                                         provider_name, fence_token_storage.FenceTokenStorage)
+                                         provider_name, fence_token_storage.FenceTokenStorage())
     return BondProvider(fence_tvm, Bond(oauth_adapter,
                                         fence_api,
                                         sam_api,

--- a/routes.py
+++ b/routes.py
@@ -143,7 +143,7 @@ def list_providers():
     return protojson.encode_message(ListProvidersResponse(providers=list(bond_providers.keys())))
 
 
-@routes.route('/api/link/v1/<provider>/oauthcode', methods=["POST"])
+@routes.route(api_routes_base + '/<provider>/oauthcode', methods=["POST"])
 @use_args({"oauthcode": fields.Str(required=True),
            "redirect_uri": fields.Str(required=True)},
           locations=("querystring",))

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -33,11 +33,6 @@ def fixup_paths(path):
 
 
 def main(sdk_path, test_path, test_pattern):
-    os.environ["current_version_id"] = "testbed.version"
-    os.environ["BOND_ACCEPTED_AUDIENCE_PREFIXES"] = "a"
-    os.environ["BOND_ACCEPTED_EMAIL_SUFFIXES"] = "foo"
-
-
     # If the SDK path points to a Google Cloud SDK installation
     # then we should alter it to point to the GAE platform location.
     if os.path.exists(os.path.join(sdk_path, 'platform/google_appengine')):


### PR DESCRIPTION
This PR is mainly aimed at re-implementing the default HTML exceptions that Flask was throwing as JSON exceptions so that they would be (nearly) identical to the errors that we threw when we used endpoints. This is part of CA-592 since it was initially left off of the work done for that ticket, but was necessary for tests to pass.


Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
