### PR TITLE
[CA-592] Remove final endpoints dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 jsonschema
-google-endpoints-api-management==1.11.0
 requests==2.20.0
 requests-oauthlib==1.0.0
 requests-toolbelt==0.8.0


### PR DESCRIPTION
I tried to do this a while ago and had a very difficult time, but this time around it worked. I believe we have either now imported the underlying libraries we cared about via other channels or something else changed so that we didn't need this dependency at all. Or maybe I was just imagining the whole thing. Regardless, I was extremely skeptical about it (ask Greg if you don't believe that), but all the tests are passing so I'm inclined to believe that this is a pretty inconsequential change.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
