### PR TITLE
CA-594 Fix deploy script and app.yaml for Python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ env/
 lib/
 linkv1openapi.json
 statusv1openapi.json
-/app.yaml
 /config.ini
 *.env.json
 

--- a/app.yaml
+++ b/app.yaml
@@ -5,3 +5,4 @@ basic_scaling:
 
 handlers:
 - url: /.*
+  script: auto

--- a/app.yaml
+++ b/app.yaml
@@ -1,13 +1,8 @@
-{{with $commonSecrets := secret (printf "secret/dsde/firecloud/common/oauth_client_id")}}
-
 runtime: python37
 entrypoint: gunicorn -b :$PORT main:app
-api_version: 1
 basic_scaling:
   max_instances: 100
 
 handlers:
 - url: /.*
   script: main.app
-
-{{end}}

--- a/app.yaml
+++ b/app.yaml
@@ -5,4 +5,3 @@ basic_scaling:
 
 handlers:
 - url: /.*
-  script: main.app

--- a/app.yaml.ctmpl
+++ b/app.yaml.ctmpl
@@ -6,16 +6,6 @@ api_version: 1
 basic_scaling:
   max_instances: 100
 
-#[START_EXCLUDE]
-skip_files:
-- ^(.*/)?#.*#$
-- ^(.*/)?.*~$
-- ^(.*/)?.*\.py[co]$
-- ^(.*/)?.*/RCS/.*$
-- ^(.*/)?\..*$
-- ^(.*/)?setuptools/script \(dev\).tmpl$
-#[END_EXCLUDE]
-
 handlers:
 - url: /.*
   script: main.app

--- a/app.yaml.ctmpl
+++ b/app.yaml.ctmpl
@@ -2,7 +2,6 @@
 
 runtime: python37
 entrypoint: gunicorn -b :$PORT main:app
-threadsafe: true
 api_version: 1
 basic_scaling:
   max_instances: 100

--- a/deploy.sh
+++ b/deploy.sh
@@ -50,13 +50,6 @@ fi
 #build the docker image so we can deploy
 docker pull ${BOND_IMAGE}
 
-#render the endpoints json and then deploy it
-docker run -v $PWD/deploy_account.json:/app/deploy_account.json \
-    -e GOOGLE_PROJECT=${GOOGLE_PROJECT} \
-    --entrypoint "/bin/bash" \
-    ${BOND_IMAGE} \
-    -c "gcloud auth activate-service-account --key-file=deploy_account.json; python lib/endpoints/endpointscfg.py get_openapi_spec main.BondApi main.BondStatusApi --hostname $GOOGLE_PROJECT.appspot.com --x-google-api-name; gcloud -q endpoints services deploy linkv1openapi.json statusv1openapi.json --project $GOOGLE_PROJECT"
-
 #SERVICE_VERSION in app.yaml needs to match the output of the curl call below
 export BUILD_TMP="${HOME}/deploy-bond-${TARGET_ENV}"
 mkdir -p ${BUILD_TMP}
@@ -86,4 +79,4 @@ docker run -v $PWD/app.yaml:/app/app.yaml \
     -e GOOGLE_PROJECT=${GOOGLE_PROJECT} \
     --entrypoint "/bin/bash" \
     ${BOND_IMAGE} \
-    -c "gcloud auth activate-service-account --key-file=deploy_account.json; gcloud -q app deploy app.yaml --project=$GOOGLE_PROJECT"
+    -c "gcloud auth activate-service-account --key-file=deploy_account.json; gcloud -q app deploy app.yaml --project=$GOOGLE_PROJECT; gcloud -q app deploy cron.yaml --project=$GOOGLE_PROJECT"

--- a/deploy.sh
+++ b/deploy.sh
@@ -50,20 +50,11 @@ fi
 #build the docker image so we can deploy
 docker pull ${BOND_IMAGE}
 
-#SERVICE_VERSION in app.yaml needs to match the output of the curl call below
-export BUILD_TMP="${HOME}/deploy-bond-${TARGET_ENV}"
-mkdir -p ${BUILD_TMP}
-export CLOUDSDK_CONFIG=${BUILD_TMP}
-
-gcloud auth activate-service-account --key-file=deploy_account.json
-SERVICE_VERSION=$(curl --silent --header "Authorization: Bearer `gcloud auth print-access-token`" https://servicemanagement.googleapis.com/v1/services/$GOOGLE_PROJECT.appspot.com/config | jq --raw-output .id)
-
 export DSDE_TOOLBOX_DOCKER_IMG=broadinstitute/dsde-toolbox:consul-0.20.0
 docker pull $DSDE_TOOLBOX_DOCKER_IMG
 #render config.ini and app.yaml for environment with SERVICE_VERSION and GOOGLE_PROJECT
 docker run -v $PWD:/app \
   -e GOOGLE_PROJ=${GOOGLE_PROJECT} \
-  -e SERVICE_VERSION=${SERVICE_VERSION} \
   -e INPUT_PATH=/app \
   -e OUT_PATH=/app \
   -e VAULT_TOKEN=${VAULT_TOKEN} \

--- a/deploy.sh
+++ b/deploy.sh
@@ -70,4 +70,4 @@ docker run -v $PWD/app.yaml:/app/app.yaml \
     -e GOOGLE_PROJECT=${GOOGLE_PROJECT} \
     --entrypoint "/bin/bash" \
     ${BOND_IMAGE} \
-    -c "gcloud auth activate-service-account --key-file=deploy_account.json; gcloud -q app deploy app.yaml --project=$GOOGLE_PROJECT; gcloud -q app deploy cron.yaml --project=$GOOGLE_PROJECT"
+    -c "gcloud auth activate-service-account --key-file=deploy_account.json && gcloud -q app deploy app.yaml --project=$GOOGLE_PROJECT && gcloud -q app deploy cron.yaml --project=$GOOGLE_PROJECT"


### PR DESCRIPTION
Add app.yaml to replace app.yaml.ctmpl now that we're not rendering any secrets into app.yaml. 

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
