### PR TITLE
[No Ticket] add config option to ignore certs for a fence provider

### DIFF
--- a/bond_app/fence_api.py
+++ b/bond_app/fence_api.py
@@ -3,11 +3,12 @@ import requests
 
 
 class FenceApi:
-    def __init__(self, base_url):
+    def __init__(self, base_url, ignore_certificates=False):
         self.credentials_google_url = base_url + "/user/credentials/google"
         self.revoke_url = base_url + "/user/oauth2/revoke"
         self.delete_service_account_url = base_url + "/user/credentials/google/"
         self.status_url = base_url + "/user/.well-known/openid-configuration"
+        self.ignore_certificates = ignore_certificates
 
     def get_credentials_google(self, access_token):
         """
@@ -45,7 +46,7 @@ class FenceApi:
         :return: 2 values: boolean ok or not, status message if not ok
         """
         try:
-            result = requests.get(url=self.status_url)
+            result = requests.get(url=self.status_url, verify=(not self.ignore_certificates))
             if result.status_code // 100 != 2:
                 return False, "fence status code {}, error body {}".format(result.status_code, result.content)
             else:

--- a/bond_app/routes.py
+++ b/bond_app/routes.py
@@ -228,7 +228,9 @@ def clear_expired_datastore_entries():
 def get_status():
     sam_base_url = config.get('sam', 'BASE_URL')
 
-    providers = {section_name: FenceApi(config.get(section_name, 'FENCE_BASE_URL'))
+    providers = {section_name: FenceApi(config.get(section_name, 'FENCE_BASE_URL'),
+                                        config.get(section_name, 'IGNORE_CERTIFICATES')
+                                        if config.has_option(section_name, 'IGNORE_CERTIFICATES') else False)
                  for section_name in config.sections() if is_provider(section_name)}
 
     sam_api = SamApi(sam_base_url)

--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -47,6 +47,7 @@ OPEN_ID_CONFIG_URL=https://staging.datastage.io/user/.well-known/openid-configur
 USER_NAME_PATH_EXPR=/context/user/name
 FENCE_BASE_URL=https://staging.datastage.io
 EXTRA_AUTHZ_URL_PARAMS={"idp": "fence"}
+IGNORE_CERTIFICATES=True
 
 [dcf-fence]
 CLIENT_ID={{ $secrets.Data.dcf_fence_client_id }}


### PR DESCRIPTION
We realized when we deployed our python 3 flask app to dev that staging.datastage.io's certificate is not valid. The old library that we used to use to talk to the provider (`urlfetch`) did not do any cert validation. However, the new library that we use (`requests`) does, and it was failing since the certificate was invalid. This PR adds a config option to not do any cert validation which serves as a workaround while we wait for datastage to fix their staging site.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
