### PR TITLE
CA-591 Fix retrieving serviceaccount/accesstoken

### DIFF
--- a/automation/helpers/json_responses.py
+++ b/automation/helpers/json_responses.py
@@ -671,6 +671,19 @@ json_schema_test_get_serviceaccount_key = {
     }
   }
 }
+json_schema_test_get_serviceaccount_accesstoken = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "token"
+  ],
+  "properties": {
+    "token": {
+      "type": "string",
+      "pattern": "ya29"
+    }
+  }
+}
 
 """Json Schemas for UnlinkLinkedUserTestCase tests"""
 json_schema_test_delete_link_for_linked_user = ""  # Delete call returns an empty body

--- a/automation/tests/api_test.py
+++ b/automation/tests/api_test.py
@@ -201,6 +201,13 @@ class LinkedUserTestCase(AuthorizedBaseCase):
         response_json_dict = json.loads(r.text)
         validate(instance=response_json_dict, schema=json_schema_test_get_serviceaccount_key)
 
+    def test_get_serviceaccount_accesstoken(self):
+        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/serviceaccount/accesstoken"
+        r = requests.get(url, headers=self.bearer_token_header(LinkedUserTestCase.token))
+        self.assertEqual(200, r.status_code, "Response code was not 200.  Response Body: %s" % r.text)
+        response_json_dict = json.loads(r.text)
+        validate(instance=response_json_dict, schema=json_schema_test_get_serviceaccount_accesstoken)
+
 
 class UnlinkLinkedUserTestCase(AuthorizedBaseCase):
     """Tests the unlink functionality when a user is already linked"""

--- a/bond_app/fence_token_vending.py
+++ b/bond_app/fence_token_vending.py
@@ -5,6 +5,7 @@ from werkzeug import exceptions
 from .bond import FenceKeys
 from .fence_token_storage import ProviderUser
 from google.oauth2 import service_account
+import google.auth.transport.requests
 from .sam_api import SamKeys
 
 
@@ -40,7 +41,8 @@ class FenceTokenVendingMachine:
             scopes = ["email", "profile"]
         key_json = self.get_service_account_key_json(user_info)
         credentials = service_account.Credentials.from_service_account_info(json.loads(key_json), scopes=scopes)
-        return credentials.get_access_token().access_token
+        credentials.refresh(google.auth.transport.requests.Request())
+        return credentials.token
 
     def get_service_account_key_json(self, user_info):
         """


### PR DESCRIPTION
Fix 3caa0a to use refresh for new OAuth credentials library.
Add an automation test for {provider}/serviceaccount/accesstoken.
Test failed before fix.

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
