### PR TITLE
CA-593 Add a SwaggerUI page to Bond

### DIFF
--- a/automation/tests/api_test.py
+++ b/automation/tests/api_test.py
@@ -51,6 +51,16 @@ class PublicApiTestCase(BaseApiTestCase):
         response_json_dict = json.loads(r.text)
         validate(instance=response_json_dict, schema=json_schema_test_get_auth_url_with_only_redirect_param)
 
+    def test_get_swagger_ui(self):
+        url = self.bond_base_url + "/api/docs"
+        r = requests.get(url)
+        self.assertEqual(200, r.status_code)
+
+    def test_get_nonexistant_url(self):
+        url = self.bond_base_url + "/not/a/url/that/exists"
+        r = requests.get(url)
+        self.assertEqual(404, r.status_code)
+
 
 class AuthorizedBaseCase(BaseApiTestCase):
     """

--- a/bond_app/swagger_ui.py
+++ b/bond_app/swagger_ui.py
@@ -2,15 +2,12 @@ from flask_swagger_ui import get_swaggerui_blueprint
 from yaml import Loader, load
 
 SWAGGER_URL = '/api/docs'  # URL for exposing Swagger UI (without trailing '/')
-API_URL = './swagger/api-docs.yaml'  # Our API url (can of course be a local resource)
 
-swagger_yml = load(open(swagger_path, 'r'), Loader=Loader)
+swagger_yml = load(open('./swagger/api-docs.yaml', 'r'), Loader=Loader)
 
 # Call factory function to create our blueprint
 swaggerui_blueprint = get_swaggerui_blueprint(
     SWAGGER_URL,  # Swagger UI static files will be mapped to '{SWAGGER_URL}/dist/'
-    API_URL,
-    config={  # Swagger UI config overrides
-        'app_name': "Bond"
-    },
+    None,
+    config={'spec': swagger_yml},
 )

--- a/bond_app/swagger_ui.py
+++ b/bond_app/swagger_ui.py
@@ -1,0 +1,16 @@
+from flask_swagger_ui import get_swaggerui_blueprint
+from yaml import Loader, load
+
+SWAGGER_URL = '/api/docs'  # URL for exposing Swagger UI (without trailing '/')
+API_URL = './swagger/api-docs.yaml'  # Our API url (can of course be a local resource)
+
+swagger_yml = load(open(swagger_path, 'r'), Loader=Loader)
+
+# Call factory function to create our blueprint
+swaggerui_blueprint = get_swaggerui_blueprint(
+    SWAGGER_URL,  # Swagger UI static files will be mapped to '{SWAGGER_URL}/dist/'
+    API_URL,
+    config={  # Swagger UI config overrides
+        'app_name': "Bond"
+    },
+)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import flask
 import os
 from bond_app import routes
+from bond_app.swagger_ui import swaggerui_blueprint, SWAGGER_URL
 from bond_app.json_exception_handler import JsonExceptionHandler
 from google.cloud import ndb
 from google.auth.credentials import AnonymousCredentials
@@ -30,6 +31,7 @@ def create_app():
     """Initializes app."""
     flask_app = flask.Flask(__name__)
     flask_app.register_blueprint(routes.routes)
+    flask_app.register_blueprint(swaggerui_blueprint, url_prefix=SWAGGER_URL)
     CORS(flask_app)
     return flask_app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ grpcio==1.26.0
 protorpc==0.12.0
 gunicorn==20.0.4
 flask-cors==3.0.8
+flask-swagger-ui==3.20.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ protorpc==0.12.0
 gunicorn==20.0.4
 flask-cors==3.0.8
 flask-swagger-ui==3.20.9
+PyYaml==5.3

--- a/swagger/api-docs.yaml
+++ b/swagger/api-docs.yaml
@@ -44,7 +44,7 @@ components:
     googleAuth:
       type: http
       scheme: bearer
-      bearerFormat: JWT
+      bearerFormat: GCloud access token
       description: Use your GCP auth token, i.e. `gcloud auth print-access-token`
 
 paths:

--- a/swagger/api-docs.yaml
+++ b/swagger/api-docs.yaml
@@ -117,7 +117,7 @@ paths:
         - name: redirect_uri
           in: query
           required: true
-          description:  A URL encoded string representing the URI that the Authorizing Service will redirect the user to after the user successfully authorizes this client.
+          description:  A URL encoded string representing the URI that the Authorizing Service will redirect the user to after the user successfully authorizes this client. Note that the redirect_uri must be registered with the provider.
           schema:
             type: string
         - name: state

--- a/swagger/api-docs.yaml
+++ b/swagger/api-docs.yaml
@@ -5,6 +5,9 @@ info:
   version: "1.0"
 
 servers:
+  - url: /
+    # '/' is a relative path to this host.
+    description: The server hosting this Swagger UI
   - url: https://broad-bond-prod.appspot.com/
     description: Production
   - url: https://broad-bond-dev.appspot.com/
@@ -82,7 +85,7 @@ paths:
                     type: array
                     items:
                       type: string
-                    example: dcf-fence
+                      example: dcf-fence
 
   /api/link/vi/{provider}/accesstoken:
     get:

--- a/swagger/api-docs.yaml
+++ b/swagger/api-docs.yaml
@@ -1,0 +1,215 @@
+openapi: 3.0.2
+info:
+  title: Bond API
+  description: Service for linking Sam User accounts with registered 3rd party providers via Oauth2. See [Bond Github](https://github.com/DataBiosphere/bond).
+  version: "1.0"
+
+servers:
+  - url: https://broad-bond-prod.appspot.com/
+    description: Production
+  - url: https://broad-bond-dev.appspot.com/
+    description: Development
+
+components:
+  parameters:
+    providerParam:
+      in: path
+      name: provider
+      required: true
+      description: The provider to link with.
+      schema:
+        type: string
+        example: dcf-fence
+
+  responses:
+    LinkInfoResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              issued_at:
+                type: string
+              username:
+                type: string
+
+    LinkNotFound:
+      description: Unable to find a link for the user to the provider. Consider re-linking with an oauthcode.
+
+  securitySchemes:
+    googleOAuth2:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: 'https://accounts.google.com/o/oauth2/auth'
+          scopes:
+            openid: open id authorization
+            email: email authorization
+            profile: profile authorization
+
+
+
+paths:
+  /api/link/vi/{provider}:
+    get:
+      summary: Returns info about the linked account for the provider, if an account has been linked.
+      parameters:
+        - $ref: '#/components/parameters/providerParam'
+      responses:
+        '200':
+          $ref: '#/components/responses/LinkInfoResponse'
+        '404':
+          $ref: '#/components/responses/LinkNotFound'
+    delete:
+      summary: Delete the account link for the provider, if an account has been linked.
+      parameters:
+        - $ref: '#/components/parameters/providerParam'
+      responses:
+        '204':
+          description: OK
+        '404':
+          $ref: '#/components/responses/LinkNotFound'
+      security:
+        - googleOAuth2: [openid, email, profile]
+
+  /api/link/v1/providers:
+    get:
+      summary: Lists the available 3rd party providers for linking accounts.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  providers:
+                    type: array
+                    items:
+                      type: string
+                    example: dcf-fence
+
+  /api/link/vi/{provider}/accesstoken:
+    get:
+      summary: Gets a new access token from the provider if the account has been linked.
+      parameters:
+        - $ref: '#/components/parameters/providerParam'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                  expires_at:
+                    type: string
+        '404':
+          $ref: '#/components/responses/LinkNotFound'
+      security:
+        - googleOAuth2: [openid, email, profile]
+
+  /api/link/v1/{provider}/authorization-url:
+    get:
+      summary: Builds an OAuth authorization URL that a user must use to initiate the OAuth dance.
+      parameters:
+        - $ref: '#/components/parameters/providerParam'
+        - name: redirect_uri
+          in: query
+          required: true
+          description:  A URL encoded string representing the URI that the Authorizing Service will redirect the user to after the user successfully authorizes this client.
+          schema:
+            type: string
+        - name: state
+          in: query
+          required: true
+          description: A URL encoded Base64 string representing a JSON object of state information that the requester requires back with the redirect.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url:
+                    type: string
+                    description: A plain (not URL encoded) String
+
+  /api/link/v1/{provider}/oauthcode:
+    post:
+      summary: Link the user's account with the provider.
+      parameters:
+        - $ref: '#/components/parameters/providerParam'
+        - name: oauthcodde
+          in: query
+          required: true
+          description: The authorization code from the provider.
+          schema:
+            type: string
+        - name: redirect_uri
+          in: query
+          required: true
+          description: The redirect url that was used when generating the authorization code.
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/LinkInfoResponse'
+      security:
+        - googleOAuth2: [openid, email, profile]
+
+  /api/link/v1/{provider}/serviceaccount/key:
+    get:
+      summary: Returns a service account json key to use to access objects for the provider as the linked account.
+      parameters:
+        - $ref: '#/components/parameters/providerParam'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+        '404':
+          $ref: '#/components/responses/LinkNotFound'
+      security:
+        - googleOAuth2: [openid, email, profile]
+
+  /api/link/v1/{provider}/serviceaccount/accesstoken:
+    get:
+      summary: Get a service account access token to access objects protected by fence.
+      parameters:
+        - $ref: '#/components/parameters/providerParam'
+        - name: scopes
+          in: query
+          required: false
+          description: scopes to request for token. Defaults to ["email", "profile"].
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+      responses:
+        '404':
+          $ref: '#/components/responses/LinkNotFound'
+      security:
+        - googleOAuth2: [openid, email, profile]
+
+  /api/status/v1/status:
+    get:
+      summary: Returns the status of the Bond server.
+      responses:
+        '200':
+          description: A JSON description of the ok subsystems.
+        '503':
+          description: A JSON description of the subsystems and any issues they might have.

--- a/swagger/api-docs.yaml
+++ b/swagger/api-docs.yaml
@@ -38,17 +38,11 @@ components:
       description: Unable to find a link for the user to the provider. Consider re-linking with an oauthcode.
 
   securitySchemes:
-    googleOAuth2:
-      type: oauth2
-      flows:
-        implicit:
-          authorizationUrl: 'https://accounts.google.com/o/oauth2/auth'
-          scopes:
-            openid: open id authorization
-            email: email authorization
-            profile: profile authorization
-
-
+    googleAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Use your GCP auth token, i.e. `gcloud auth print-access-token`
 
 paths:
   /api/link/vi/{provider}:
@@ -71,7 +65,7 @@ paths:
         '404':
           $ref: '#/components/responses/LinkNotFound'
       security:
-        - googleOAuth2: [openid, email, profile]
+        - googleAuth: []
 
   /api/link/v1/providers:
     get:
@@ -110,7 +104,7 @@ paths:
         '404':
           $ref: '#/components/responses/LinkNotFound'
       security:
-        - googleOAuth2: [openid, email, profile]
+        - googleAuth: []
 
   /api/link/v1/{provider}/authorization-url:
     get:
@@ -162,7 +156,7 @@ paths:
         '200':
           $ref: '#/components/responses/LinkInfoResponse'
       security:
-        - googleOAuth2: [openid, email, profile]
+        - googleAuth: []
 
   /api/link/v1/{provider}/serviceaccount/key:
     get:
@@ -182,7 +176,7 @@ paths:
         '404':
           $ref: '#/components/responses/LinkNotFound'
       security:
-        - googleOAuth2: [openid, email, profile]
+        - googleAuth: []
 
   /api/link/v1/{provider}/serviceaccount/accesstoken:
     get:
@@ -203,7 +197,7 @@ paths:
         '404':
           $ref: '#/components/responses/LinkNotFound'
       security:
-        - googleOAuth2: [openid, email, profile]
+        - googleAuth: []
 
   /api/status/v1/status:
     get:


### PR DESCRIPTION
Adds an OpenApi v3 yaml describing bonds endpoints.
Make Bond host the SwaggerUI page with flask-swagger-ui.
Add an automated test to check that the SwaggerUI page exists.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
