### PR TITLE
CA-648 Fix cron route to use GET instead of POST

### DIFF
--- a/automation/tests/api_test.py
+++ b/automation/tests/api_test.py
@@ -52,6 +52,23 @@ class PublicApiTestCase(BaseApiTestCase):
         validate(instance=response_json_dict, schema=json_schema_test_get_auth_url_with_only_redirect_param)
 
 
+class CronApiTestCase(BaseApiTestCase):
+    """Tests Bond APIs that are for GAE cron use."""
+    CRON_HEADER = {"X-Appengine-Cron": "true"}
+
+    def test_clear_cache_with_cron_header(self):
+        url = self.bond_base_url + "/api/link/v1/clear-expired-cache-datastore-entries"
+        r = requests.get(url, headers=CronApiTestCase.CRON_HEADER)
+        self.assertEqual(204, r.status_code)
+
+    def test_clear_cache_without_cron_header(self):
+        url = self.bond_base_url + "/api/link/v1/clear-expired-cache-datastore-entries"
+        r = requests.get(url, headers={})
+        self.assertEqual(401, r.status_code)
+        response_json_dict = json.loads(r.text)
+        self.assertEqual("Missing required cron header.", response_json_dict["error"]["message"])
+
+
 class AuthorizedBaseCase(BaseApiTestCase):
     """
     Provides UserCredentials objects for obtaining OAuth2 Access Tokens that we can use as bearer tokens during

--- a/bond_app/routes.py
+++ b/bond_app/routes.py
@@ -216,7 +216,7 @@ def authorization_url(args, provider):
     return protojson.encode_message((AuthorizationUrlResponse(url=authz_url)))
 
 
-@routes.route(v1_link_route_base + '/clear-expired-cache-datastore-entries', methods=["POST"], strict_slashes=False)
+@routes.route(v1_link_route_base + '/clear-expired-cache-datastore-entries', methods=["GET"], strict_slashes=False)
 def clear_expired_datastore_entries():
     # Only allow Appengine cron to hit this endpoint.
     if not request.headers.get("X-Appengine-Cron"):


### PR DESCRIPTION
cron.yaml issues gets, not posts. https://cloud.google.com/appengine/docs/flexible/python/scheduling-jobs-with-cron-yaml
Add test cases to api_test. Now that we're on flask and not GAE python 2, there's no magic header stripping in our local server runs.
\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
