### PR TITLE
Fix openapi typo in paths.

### DIFF
--- a/swagger/api-docs.yaml
+++ b/swagger/api-docs.yaml
@@ -48,7 +48,7 @@ components:
       description: Use your GCP auth token, i.e. `gcloud auth print-access-token`
 
 paths:
-  /api/link/vi/{provider}:
+  /api/link/v1/{provider}:
     get:
       summary: Returns info about the linked account for the provider, if an account has been linked.
       parameters:
@@ -87,7 +87,7 @@ paths:
                       type: string
                       example: dcf-fence
 
-  /api/link/vi/{provider}/accesstoken:
+  /api/link/v1/{provider}/accesstoken:
     get:
       summary: Gets a new access token from the provider if the account has been linked.
       parameters:


### PR DESCRIPTION
s/vi/v1

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
