### PR TITLE
CA-594 Update Bond readme for python3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bond
 
 Service for linking [Sam](https://github.com/broadinstitute/sam) User accounts with registered 3rd party services via
-Oauth2. Bond is a [Google Endpoints](https://cloud.google.com/endpoints/) application written in Python 2.7.
+Oauth2. Bond is a Flask application written in Python 3.7 deployed on Google App Engine.
 
 # Setup
 
@@ -31,7 +31,7 @@ When you are ready to exit or deactivate your Bond virtualenv, just type the com
 
 Bond has unit tests, integration tests, and automation tests. 
 
-Bond supports test runners: [unittest](https://docs.python.org/2/library/unittest.html).
+Bond supports test runners: [unittest](https://docs.python.org/3/library/unittest.html).
 
 ## Unit tests
 
@@ -103,13 +103,13 @@ Choose one of the options below:
 a) To run an existing image:
 
 1) Browse the available tags [here](https://quay.io/repository/databiosphere/bond?tag=latest&tab=tags)
-2) With your tag of choice (such as `develop`), run `docker run -v $PWD/config.ini:/app/config.ini -v $PWD/app.yaml:/app/app.yaml -p=8080:8080 quay.io/databiosphere/bond:{TAG}`
+2) With your tag of choice (such as `develop`), run `IMAGE_ID=quay.io/databiosphere/bond:{TAG} docker-compose -f docker/local-docker-compose.yml up`
 3) Check http://localhost:8080/api/status/v1/status to make sure you're up and running
 
 b) Run your local code:
 
 1) Build your image: `docker build -f docker/Dockerfile .`
-2) Grab the Image ID and run: `docker run -v $PWD/config.ini:/app/config.ini -v $PWD/app.yaml:/app/app.yaml -p=8080:8080 {IMAGE_ID}`
+2) Grab the Image ID and run: `IMAGE_ID={your image id} docker-compose -f docker/local-docker-compose.yml up`
 3) Check http://localhost:8080/api/status/v1/status to make sure you're up and running
 
 # Deployment (for Broad only)

--- a/docker/local-docker-compose.yml
+++ b/docker/local-docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+  bond-app:
+    # Image id from local docker build or remote image like 'quay.io/databiosphere/bond:{tag}'
+    image: $IMAGE_ID
+    volumes:
+      # Use locally rendered config.ini file.
+      - $PWD/config.ini:/app/config.ini
+    ports:
+      - "8080:8080"
+    environment:
+      DATASTORE_EMULATOR_HOST: datastore-emulator:8432
+  datastore-emulator:
+    image: google/cloud-sdk:276.0.0
+    # Use local run_emulator.sh.
+    volumes:
+      - $PWD/tests/datastore_emulator/run_emulator.sh:/run_emulator.sh
+    command: /run_emulator.sh


### PR DESCRIPTION
Add a docker-compose file for running docker images locally connecting to a datastore emulator now that we can't just run the docker images.

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
