### PR TITLE
[No ticket] Fix broken status logs

### DIFF
--- a/bond_app/routes.py
+++ b/bond_app/routes.py
@@ -251,5 +251,5 @@ def get_status():
     if ok:
         return response
     else:
-        logging.warning("Bond status NOT OK:\n%s" % response)
-        raise exceptions.InternalServerError(response)
+        logging.warning("Bond status NOT OK:\n%s" % response[0])
+        raise exceptions.InternalServerError(response[0])


### PR DESCRIPTION
In order to fix the content type response stuff, we had to start returning a tuple in our responses, including the status response. However, when the status was not ok, we would log that status and expect the status to be json. The json that we were logging was changed to a tuple for content type, but that broke our status logging. This PR now grabs the first element out of the tuple, which is the json we want, and logs that when Bond's status is not ok.

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
