### PR TITLE
CA-785 Add security block to swagger (PR #2)

### DIFF
--- a/swagger/api-docs.yaml
+++ b/swagger/api-docs.yaml
@@ -58,6 +58,8 @@ paths:
           $ref: '#/components/responses/LinkInfoResponse'
         '404':
           $ref: '#/components/responses/LinkNotFound'
+      security:
+        - googleAuth: []
     delete:
       summary: Delete the account link for the provider, if an account has been linked.
       parameters:


### PR DESCRIPTION
GET /api/link/v1/{provider} needs to have a security block specified so that an Authorization header is sent on requests from Swagger UI

This PR is attempt #2 to merge this branch.  The first PR (https://github.com/DataBiosphere/bond/pull/143) was approved, but for whatever reason it failed to trigger the requisite Workflows in CircleCI. 


Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
