### PR TITLE
Gpolumbo ca 789 anvil provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,27 @@ When writing new tests, do not put any tests in the root `tests/` directory.  In
 
 To run integration tests, provide the `test-path` parameter to with the path to the integration tests:
 
-`python -m unittest discover -s tests/integration -p "*_test.py"`
+`python -m unittest discover -s tests/integration -p "*_test.py"` 
 
 When writing new tests, do not put any tests in the root `tests/` directory.  Instead, write new integration tests in 
 the `tests/integration` directory.
+
+### Integration testing with real providers
+Integration tests are written to be run against the [mock provider service](https://github.com/broadinstitute/mock-provider).
+The mock provider service skips the authentication step of the oauth dance in order to make testing easier.  
+
+If you want to test against _real_ providers, do the following:
+
+1. Update `config.ini` to have all the requisite data for the real providers
+1. In the `get_auth_code` method in `tests/integration/oauth_adapter_test.py`, set the variable `using_mock_providers =
+False`. 
+1. Run the Integration Tests the same way as described above.  The tests will stop and print instructions and a link to 
+authenticate with each provider.  Follow the instructions and copy/paste the `auth_code` into the command line for each 
+provider to complete the oauth dance.
+
+Because the test execution will become an interactive experience, you **_must_** run these tests in an environment
+where you can provide the required command line inputs.  In other words, you won't be able to run tests this way on a 
+build server, but you will be able to run them in your local environment.
 
 ## Datastore Emulator tests
 To run the integration tests that require the Datastore emulator locally, follow [the instructions in the readme](tests/datastore_emulator/README.md). 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,11 @@ Once installed, you can add the following patterns:
 git secrets --add 'CLIENT_ID\s*=\s*.+'
 git secrets --add 'CLIENT_SECRET\s*=\s*.+'
 git secrets --add --allowed 'REPLACE_ME'
-git secrets --add --allowed '\{\{ \$fenceSecrets\.Data\.client_id \}\}'
-git secrets --add --allowed '\{\{ \$fenceSecrets\.Data\.client_secret \}\}'
+git secrets --add --allowed 'ignored'
+git secrets --add --allowed '\{\{ \$secrets\.Data\.client_id \}\}'
+git secrets --add --allowed '\{\{ \$secrets\.Data\.client_secret \}\}'
+git secrets --add --allowed '\{\{ \$secrets\.Data\.dcf_fence_client_id \}\}'
+git secrets --add --allowed '\{\{ \$secrets\.Data\.dcf_fence_client_secret \}\}'
+git secrets --add --allowed '\{\{ \$secrets\.Data\.anvil_client_id \}\}'
+git secrets --add --allowed '\{\{ \$secrets\.Data\.anvil_secret \}\}'
 ```

--- a/bond_app/oauth_adapter.py
+++ b/bond_app/oauth_adapter.py
@@ -32,6 +32,7 @@ class OauthAdapter:
         authz_endpoint = self.open_id_config.get_config_value("authorization_endpoint")
         oauth = OAuth2Session(self.client_id, redirect_uri=redirect_uri, scope=scopes, state=state)
         authorization_url, state = oauth.authorization_url(authz_endpoint, **extra_authz_url_params)
+        oauth.close()
         return authorization_url
 
     def exchange_authz_code(self, authz_code, redirect_uri):
@@ -42,7 +43,9 @@ class OauthAdapter:
         :return: A token dict including the access token, refresh token, and token type (amongst other details)
         """
         oauth = OAuth2Session(self.client_id, redirect_uri=redirect_uri)
-        return oauth.fetch_token(self.open_id_config.get_token_info_url(), code=authz_code, auth=self.basic_auth)
+        token_dict = oauth.fetch_token(self.open_id_config.get_token_info_url(), code=authz_code, auth=self.basic_auth)
+        oauth.close()
+        return token_dict
 
     def refresh_access_token(self, refresh_token_str):
         """
@@ -52,7 +55,9 @@ class OauthAdapter:
         """
         token_dict = {'refresh_token': refresh_token_str}
         oauth = OAuth2Session(self.client_id, token=token_dict)
-        return oauth.refresh_token(self.open_id_config.get_token_info_url(), auth=self.basic_auth)
+        token = oauth.refresh_token(self.open_id_config.get_token_info_url(), auth=self.basic_auth)
+        oauth.close()
+        return token
 
     def revoke_refresh_token(self, refresh_token):
         """

--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -21,6 +21,13 @@ OPEN_ID_CONFIG_URL=https://storage.googleapis.com/wb-dev-mock-provider/well-know
 USER_NAME_PATH_EXPR=/username
 FENCE_BASE_URL=https://us-central1-broad-dsde-dev.cloudfunctions.net
 
+[anvil]
+CLIENT_ID=ignored
+CLIENT_SECRET=ignored
+OPEN_ID_CONFIG_URL=https://storage.googleapis.com/wb-dev-mock-provider/well-known.json
+USER_NAME_PATH_EXPR=/username
+FENCE_BASE_URL=https://us-central1-broad-dsde-dev.cloudfunctions.net
+
 {{else if eq $environment "prod"}}
 [fence]
 CLIENT_ID={{ $secrets.Data.client_id }}

--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -38,6 +38,13 @@ OPEN_ID_CONFIG_URL=https://nci-crdc.datacommons.io/user/.well-known/openid-confi
 USER_NAME_PATH_EXPR=/context/user/name
 FENCE_BASE_URL=https://nci-crdc.datacommons.io
 
+[anvil]
+CLIENT_ID={{ $secrets.Data.anvil_client_id }}
+CLIENT_SECRET={{ $secrets.Data.anvil_secret }}
+OPEN_ID_CONFIG_URL=https://gen3.theanvil.io/user/.well-known/openid-configuration
+USER_NAME_PATH_EXPR=/context/user/name
+FENCE_BASE_URL=https://gen3.theanvil.io/
+
 {{else}}
 # Non-production environments
 [fence]
@@ -54,6 +61,13 @@ CLIENT_SECRET={{ $secrets.Data.dcf_fence_client_secret }}
 OPEN_ID_CONFIG_URL=https://nci-crdc-staging.datacommons.io/user/.well-known/openid-configuration
 USER_NAME_PATH_EXPR=/context/user/name
 FENCE_BASE_URL=https://nci-crdc-staging.datacommons.io
+
+[anvil]
+CLIENT_ID={{ $secrets.Data.anvil_client_id }}
+CLIENT_SECRET={{ $secrets.Data.anvil_secret }}
+OPEN_ID_CONFIG_URL=https://staging.theanvil.io/user/.well-known/openid-configuration
+USER_NAME_PATH_EXPR=/context/user/name
+FENCE_BASE_URL=https://staging.theanvil.io/
 
 {{end}}
 

--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -21,13 +21,6 @@ OPEN_ID_CONFIG_URL=https://storage.googleapis.com/wb-dev-mock-provider/well-know
 USER_NAME_PATH_EXPR=/username
 FENCE_BASE_URL=https://us-central1-broad-dsde-dev.cloudfunctions.net
 
-[anvil]
-CLIENT_ID=ignored
-CLIENT_SECRET=ignored
-OPEN_ID_CONFIG_URL=https://storage.googleapis.com/wb-dev-mock-provider/well-known.json
-USER_NAME_PATH_EXPR=/username
-FENCE_BASE_URL=https://us-central1-broad-dsde-dev.cloudfunctions.net
-
 {{else if eq $environment "prod"}}
 [fence]
 CLIENT_ID={{ $secrets.Data.client_id }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jsonschema==3.2.0
 requests==2.20.0
-requests-oauthlib==1.0.0
+requests-oauthlib==1.3.0
 requests-toolbelt==0.8.0
 pyjwt==1.6.4
 mock==2.0.0

--- a/tests/integration/oauth_adapter_test.py
+++ b/tests/integration/oauth_adapter_test.py
@@ -1,15 +1,17 @@
 import configparser
-import unittest
 import re
-import urllib.request, urllib.parse, urllib.error
 import sys
 import time
+import unittest
+import urllib.error
+import urllib.parse
+import urllib.request
 
 from bond_app.bond import FenceKeys
-from tests.unit.fake_cache_api import FakeCacheApi
 from bond_app.jwt_token import JwtToken
 from bond_app.oauth_adapter import OauthAdapter
 from bond_app.open_id_config import OpenIdConfig
+from tests.unit.fake_cache_api import FakeCacheApi
 
 
 class OauthAdapterTestCase(unittest.TestCase):
@@ -49,14 +51,27 @@ class OauthAdapterTestCase(unittest.TestCase):
                                                       redirect_uri,
                                                       state,
                                                       extra_authz_url_params={"foo": "bar"})
-            print("Please go to %s to authorize access: %s" % (provider, authz_url))
-            print("YOU WILL BE REDIRECTED TO %s WHICH WILL PROBABLY UNREACHABLE -- THIS IS EXPECTED!" % redirect_uri)
-            print("Please copy/paste the \"code\" parameter from the resulting URL: ")
-            sys.stdout.flush()
-            # auth_code = sys.stdin.readline().strip()
-            auth_code = "X"
+            auth_code = cls.get_auth_code(authz_url, provider, redirect_uri)
             authz_responses[provider] = oauth_adapter.exchange_authz_code(auth_code, redirect_uri)
         return authz_responses
+
+    # If we're testing against mock providers, we don't care what the `auth_code` is that we exchange with the provider.
+    # If you want to run these tests against real providers, you will need to set the `using_mock_providers` variable to
+    # be `False`, which means that the test execution will require the test runner to follow the generated links to
+    # log into each provider and paste the auth code into the terminal in order to complete the oauth token exchange
+    # required for the tests to execute against a real provider.
+    @classmethod
+    def get_auth_code(cls, authz_url, provider, redirect_uri):
+        using_mock_providers = True
+        return "X" if using_mock_providers else cls.ask_user_for_auth_code(authz_url, provider, redirect_uri)
+
+    @classmethod
+    def ask_user_for_auth_code(cls, authz_url, provider, redirect_uri):
+        print("Please go to %s to authorize access: %s" % (provider, authz_url))
+        print("YOU WILL BE REDIRECTED TO %s WHICH WILL PROBABLY UNREACHABLE -- THIS IS EXPECTED!" % redirect_uri)
+        print("Please copy/paste the \"code\" parameter from the resulting URL: ")
+        sys.stdout.flush()
+        return sys.stdin.readline().strip()
 
     @staticmethod
     def param_regex(key, value):

--- a/tests/integration/oauth_adapter_test.py
+++ b/tests/integration/oauth_adapter_test.py
@@ -26,6 +26,7 @@ class OauthAdapterTestCase(unittest.TestCase):
         OauthAdapterTestCase.config = configparser.ConfigParser()
         OauthAdapterTestCase.config.read("config.ini")
         OauthAdapterTestCase.oauth_adapters = OauthAdapterTestCase.init_oauth_adapters(OauthAdapterTestCase.config)
+        print("Testing %i provider(s) per test: [%s]" % (len(OauthAdapterTestCase.oauth_adapters), list(OauthAdapterTestCase.oauth_adapters)))
         OauthAdapterTestCase.authz_responses = OauthAdapterTestCase.authorize_with_providers(OauthAdapterTestCase.oauth_adapters)
 
     @classmethod


### PR DESCRIPTION
In addition to adding the new Anvil Provider, this PR makes some modifcations to the Integration tests to provide instructions for, and make it easier to, swap between running them against the mock_provider service or real fences.  Also made some changes to get rid of various warnings that were cluttering the output of the integration test runs.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
