### PR TITLE
[CA-943] Tolerate unlinking expired refresh tokens

### DIFF
--- a/bond_app/fence_api.py
+++ b/bond_app/fence_api.py
@@ -37,7 +37,9 @@ class FenceApi:
     def revoke_refresh_token(self, refresh_token):
         result = requests.post(url=self.revoke_url, data=refresh_token)
         if result.status_code // 100 != 2:
-            raise exceptions.InternalServerError("fence status code {}, error body {}".format(result.status_code, result.content))
+            if result.status_code != 400:
+                raise exceptions.InternalServerError("fence status code {}, error body {}"
+                                                     .format(result.status_code, result.content))
 
     def status(self):
         """

--- a/bond_app/oauth_adapter.py
+++ b/bond_app/oauth_adapter.py
@@ -1,5 +1,6 @@
 import base64
 from werkzeug import exceptions
+import logging
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -70,6 +71,7 @@ class OauthAdapter:
                                data={"token": refresh_token},
                                headers={"Authorization": "Basic %s" % base64.b64encode(
                                    "{}:{}".format(self.client_id, self.client_secret).encode()).decode()})
+        logging.info("POST {} - status code: {}".format(revoke_url, result.status_code))
         if result.status_code // 100 != 2:
             # If the refresh token has already expired, the auth provider will return a 400 when we try to revoke it.
             # We don't want to fail if that happens, we just want to keep going and delete the expired token on our end

--- a/bond_app/oauth_adapter.py
+++ b/bond_app/oauth_adapter.py
@@ -71,7 +71,7 @@ class OauthAdapter:
                                data={"token": refresh_token},
                                headers={"Authorization": "Basic %s" % base64.b64encode(
                                    "{}:{}".format(self.client_id, self.client_secret).encode()).decode()})
-        logging.info("POST {} - status code: {}".format(revoke_url, result.status_code))
+        logging.info("request: POST {} - status code: {}".format(revoke_url, result.status_code))
         if result.status_code // 100 != 2:
             # If the refresh token has already expired, the auth provider will return a 400 when we try to revoke it.
             # We don't want to fail if that happens, we just want to keep going and delete the expired token on our end

--- a/bond_app/oauth_adapter.py
+++ b/bond_app/oauth_adapter.py
@@ -71,5 +71,8 @@ class OauthAdapter:
                                headers={"Authorization": "Basic %s" % base64.b64encode(
                                    "{}:{}".format(self.client_id, self.client_secret).encode()).decode()})
         if result.status_code // 100 != 2:
-            raise exceptions.InternalServerError("revoke url {}, status code {}, error body {}".
-                                                 format(revoke_url, result.status_code, result.content))
+            # If the refresh token has already expired, the auth provider will return a 400 when we try to revoke it.
+            # We don't want to fail if that happens, we just want to keep going and delete the expired token on our end
+            if result.status_code != 400:
+                raise exceptions.InternalServerError("revoke url {}, status code {}, error body {}"
+                                                     .format(revoke_url, result.status_code, result.content))


### PR DESCRIPTION
Ticket: [CA-943](https://broadworkbench.atlassian.net/browse/CA-943)
When we try to revoke a refresh token that has already expired, `fence` responds with a 400. This PR allows Bond to tolerate that 400 and continue and delete the refresh token from the token store.

Still need to figure out how best to test both this and unlinking more generally.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
