### PR TITLE
[CA-985] delete SA key from cache when removing service account while unlinking

### DIFF
--- a/bond_app/cache_api.py
+++ b/bond_app/cache_api.py
@@ -18,3 +18,12 @@ class CacheApi:
         :return: The value of the key if found, else None.
         """
         raise NotImplementedError
+
+    def delete(self, key, namespace=None):
+        """
+        Deletes the value specified by key
+        :param key: A string key
+        :param namespace: The namespace used for the 'add' if any.
+        :return: None if entry at key was deleted or not found
+        """
+        raise NotImplementedError

--- a/bond_app/datastore_cache_api.py
+++ b/bond_app/datastore_cache_api.py
@@ -35,6 +35,9 @@ class DatastoreCacheApi(CacheApi):
             return None
         return entry.value
 
+    def delete(self, key, namespace=None):
+        DatastoreCacheApi._build_cache_key(key, namespace).delete()
+
     @staticmethod
     def delete_expired_entries():
         """Deletes the entries that have expired. This must be done periodically. """

--- a/bond_app/fence_token_vending.py
+++ b/bond_app/fence_token_vending.py
@@ -27,7 +27,8 @@ class FenceTokenVendingMachine:
         if key_json:
             access_token = self._get_oauth_access_token(provider_user)
             key_id = json.loads(key_json)["private_key_id"]
-            # deleting the key will invalidate anything cached
+            # keys in cache will be invalid after we delete them with Google, but clear out the cache for good measure
+            self.cache_api.delete(namespace=self.provider_name, key=user_id)
             self.fence_api.delete_credentials_google(access_token, key_id)
 
     def get_service_account_access_token(self, user_info, scopes=None):

--- a/tests/datastore_emulator/fence_token_vending_test.py
+++ b/tests/datastore_emulator/fence_token_vending_test.py
@@ -1,0 +1,73 @@
+from bond_app.fence_token_vending import FenceTokenVendingMachine
+from bond_app.fence_token_storage import FenceTokenStorage
+from bond_app.datastore_cache_api import DatastoreCacheApi
+from bond_app.sam_api import SamKeys, SamApi
+from bond_app.fence_api import FenceApi
+from bond_app.oauth_adapter import OauthAdapter
+from bond_app.authentication import UserInfo
+from tests.unit.fake_token_store import FakeTokenStore
+from mock import MagicMock
+
+import unittest
+import datetime
+import random
+import string
+from tests.datastore_emulator import datastore_emulator_utils
+
+
+class FenceTokenVendingTestCase(unittest.TestCase):
+
+    def setUp(self):
+        # Make sure to run these tests with a Datastore Emulator running or else they will fail with 'InternalError.'
+        # See the README in this directory.
+
+        datastore_emulator_utils.setUp(self)
+        self.cache_api = DatastoreCacheApi()
+        self.refresh_token_store = FakeTokenStore()
+        self.provider_name = "fake_provider"
+        self.fence_token_storage = FenceTokenStorage()
+
+    def test_remove_service_account_from_cache(self):
+        fake_token = "fake_token"
+        user_info = UserInfo(self._random_subject_id(), "splat@bar.com", fake_token, 10)
+        expected_json = '{"private_key_id": "fake_token_value"}'
+
+        ftvm = FenceTokenVendingMachine(self._mock_fence_api(expected_json),
+                                        self._mock_sam_api(user_info.id, user_info.email),
+                                        self.cache_api,
+                                        self.refresh_token_store,
+                                        self._mock_oauth_adapter(fake_token),
+                                        self.provider_name,
+                                        self.fence_token_storage)
+        self.refresh_token_store.save(user_info.id,
+                                      fake_token,
+                                      datetime.datetime.now(),
+                                      user_info.email,
+                                      self.provider_name)
+        key = ftvm.get_service_account_key_json(user_info)
+        self.assertEqual(self.cache_api.get(namespace=self.provider_name, key=user_info.id), key)
+        ftvm.remove_service_account(user_info.id)
+        self.assertIsNone(self.cache_api.get(namespace=self.provider_name, key=user_info.id))
+
+    @staticmethod
+    def _random_subject_id():
+        return ''.join(random.choice(string.digits) for _ in list(range(21)))
+
+    @staticmethod
+    def _mock_sam_api(subject_id, email):
+        sam_api = SamApi("")
+        sam_api.user_info = MagicMock(return_value={SamKeys.USER_ID_KEY: subject_id, SamKeys.USER_EMAIL_KEY: email})
+        return sam_api
+
+    @staticmethod
+    def _mock_fence_api(service_account_json):
+        fence_api = FenceApi("")
+        fence_api.get_credentials_google = MagicMock(return_value=service_account_json)
+        fence_api.delete_credentials_google = MagicMock(return_value=service_account_json)
+        return fence_api
+
+    @staticmethod
+    def _mock_oauth_adapter(access_token):
+        oauth_adapter = OauthAdapter("", "", "", "")
+        oauth_adapter.refresh_access_token = MagicMock(return_value={"access_token": access_token})
+        return oauth_adapter

--- a/tests/unit/cache_api_test.py
+++ b/tests/unit/cache_api_test.py
@@ -41,6 +41,23 @@ class CacheApiTest(object):
         self.assertIsNone(self.cache.get('foo'))
         self.assertIsNone(self.cache.get('foo', namespace='bar'))
 
+    def test_simple_delete(self):
+        self.assertTrue(self.cache.add('foo', 42))
+        self.assertEqual(self.cache.get('foo'), 42)
+        self.assertIsNone(self.cache.delete('foo'))
+        self.assertIsNone(self.cache.get('foo'))
+
+    def test_delete_with_namespace(self):
+        self.assertTrue(self.cache.add('bar', 11, namespace='baz'))
+        self.assertIsNone(self.cache.get('bar'))
+        self.assertEqual(self.cache.get('bar', namespace='baz'), 11)
+        self.assertIsNone(self.cache.delete('bar', namespace='baz'))
+        self.assertIsNone(self.cache.get('bar', namespace='baz'))
+
+    def test_delete_tolerates_missing_key(self):
+        self.assertIsNone(self.cache.delete('foo'))
+        self.assertIsNone(self.cache.delete('foo', namespace='bar'))
+
 
 class FakeCacheApiTestCase(unittest.TestCase, CacheApiTest):
     def setUp(self):

--- a/tests/unit/fake_cache_api.py
+++ b/tests/unit/fake_cache_api.py
@@ -46,3 +46,12 @@ class FakeCacheApi(CacheApi):
         else:
             timed_value = self.cache.get(key)
         return timed_value.get_valid_value() if timed_value else None
+
+    def delete(self, key, namespace=None):
+        if namespace:
+            namespace_dict = self.namespaces.get(namespace)
+            if not namespace_dict:
+                return None
+            namespace_dict.pop(key, None)
+        else:
+            self.cache.pop(key, None)


### PR DESCRIPTION
Ticket: [CA-985](https://broadworkbench.atlassian.net/browse/CA-985)
We used to just let deleted keys for unlinked accounts hang around in the cache until they expired and were cleaned up by the cron job, but this PR changes that so that we will clear any keys out when an account is unlinked. This prevents the behavior described in the ticket where a user can unlink using Bond and continue to get the cached SA key. Although that SA key should be invalid after we delete it with Fence while unlinking, it is still good practice to clear it out of the cache when we are deleting all other credentials for the user.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
