### PR TITLE
[CA-986] clear out cache when re-linking

### DIFF
--- a/bond_app/bond.py
+++ b/bond_app/bond.py
@@ -57,6 +57,10 @@ class Bond:
             logging.info(
                 "Exchange authz code did not include refresh token in response.\n{}".format(str(token_response)))
             raise exceptions.BadRequest("authorization response did not include " + FenceKeys.REFRESH_TOKEN)
+
+        if self.refresh_token_store.lookup(user_id, self.provider_name) is not None:
+            # clear out any existing information if user has previously linked this account before relinking
+            self.unlink_account(user_info)
         self.refresh_token_store.save(user_id, token_response.get(FenceKeys.REFRESH_TOKEN), jwt_token.issued_at,
                                       jwt_token.username, self.provider_name)
         return jwt_token.issued_at, jwt_token.username


### PR DESCRIPTION
Ticket: [CA-986](https://broadworkbench.atlassian.net/browse/CA-986)
If the user already has an existing link and are re-linking, we clear out all existing credentials that we have stored in Bond before we store the new stuff

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
