### PR TITLE
[CA-1038] More tolerant of expired refresh tokens when unlinking

### DIFF
--- a/bond_app/fence_api.py
+++ b/bond_app/fence_api.py
@@ -33,7 +33,7 @@ class FenceApi:
         headers = {'Authorization': 'Bearer ' + access_token}
         result = requests.delete(url=self.delete_service_account_url + key_id, headers=headers)
         logging.info("request: DELETE {} - status code: {}".format(self.delete_service_account_url, result.status_code))
-        if result.status_code // 100 != 2 or result.status_code // 100 != 4:
+        if result.status_code // 100 != 2 and result.status_code // 100 != 4:
             raise exceptions.InternalServerError("fence status code {}, error body {}".format(result.status_code, result.content))
 
     def revoke_refresh_token(self, refresh_token):

--- a/bond_app/fence_api.py
+++ b/bond_app/fence_api.py
@@ -1,5 +1,6 @@
 from werkzeug import exceptions
 import requests
+import logging
 
 
 class FenceApi:
@@ -31,7 +32,8 @@ class FenceApi:
         """
         headers = {'Authorization': 'Bearer ' + access_token}
         result = requests.delete(url=self.delete_service_account_url + key_id, headers=headers)
-        if result.status_code // 100 != 2:
+        logging.info("request: DELETE {} - status code: {}".format(self.delete_service_account_url, result.status_code))
+        if result.status_code // 100 != 2 or result.status_code // 100 != 4:
             raise exceptions.InternalServerError("fence status code {}, error body {}".format(result.status_code, result.content))
 
     def revoke_refresh_token(self, refresh_token):

--- a/bond_app/fence_api.py
+++ b/bond_app/fence_api.py
@@ -33,6 +33,9 @@ class FenceApi:
         headers = {'Authorization': 'Bearer ' + access_token}
         result = requests.delete(url=self.delete_service_account_url + key_id, headers=headers)
         logging.info("request: DELETE {} - status code: {}".format(self.delete_service_account_url, result.status_code))
+        # Sometimes Fence returns a 4xx error like when it cannot find the key_id that we are trying to delete. From
+        # our perspective, that's fine, we wanted to delete that key anyways, so if Fence has already deleted it and no
+        # longer knows about it, then our work is done. Rather than disrupt the unlinking process, we tolerate the 4xx
         if result.status_code // 100 != 2 and result.status_code // 100 != 4:
             raise exceptions.InternalServerError("fence status code {}, error body {}".format(result.status_code, result.content))
 


### PR DESCRIPTION
Ticket: [CA-1038](https://broadworkbench.atlassian.net/browse/CA-1038)

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
