### PR TITLE
[CA-1085] Update readme to comply with 2 review policy 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ I, the developer opening this PR, do solemnly pinky swear that:
 
 In all cases:
 
-- [ ] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb.
+- [ ] Get two thumbsworth of review and PO signoff if necessary. 
 - [ ] Verify all tests go green
 - [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
 - [ ] Test this change deployed correctly and works on dev environment after deployment

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ When doing a production deployment, each step of the checklist must be performed
 - [ ] For each Jira Issue included in this release, set the `Fix Version` field to the release name you created in the
       previous step.  The status of each of these issues should be: "Merged to Dev".  If the status is something else,
       then either: the issue should not be included in the release, the release is not ready, or the issue has already 
-      been released.
+      been released. Each Jira issue must have a clear description of the change and its security impact.
 
 ### Deploy and Test
 You must deploy to each tier one-by-one and [manually test](https://docs.google.com/document/d/1-SXw-tgt1tb3FEuNCGHWIZJ304POmfz5ragpphlq2Ng/edit?ts=5e964fbe#)


### PR DESCRIPTION
Ticket: [CA-1085](https://broadworkbench.atlassian.net/browse/CA-1085)
* Full details can be found in [Code Review Policy: Process Clarification & Remediation](https://docs.google.com/document/d/1ZUl8rGRl3dKvVUGsyJtLlvaUvb1l18Oo1BQv45dPnL8/edit?usp=sharing)
* Bond now has 2 mandatory PR level reviews
* The release checklist now includes checking that all tickets to be released should have a clear description of the change as well as its security impact. _Technically_, this should be done by the engineer when they pick up the ticket to start working on it, but it is the job of the releasing engineer to ensure that this information is present for all changes we release.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary. Documentation PRs only need 1 thumb. (to be removed!)
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
