### PR TITLE
[CA-1291] Add kids first as a provider

### DIFF
--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -45,6 +45,13 @@ OPEN_ID_CONFIG_URL=https://gen3.theanvil.io/user/.well-known/openid-configuratio
 USER_NAME_PATH_EXPR=/context/user/name
 FENCE_BASE_URL=https://gen3.theanvil.io/
 
+[kids-first]
+CLIENT_ID={{ $secrets.Data.kids_first_client_id }}
+CLIENT_SECRET={{ $secrets.Data.kids_first_client_id }}
+OPEN_ID_CONFIG_URL=https://data.kidsfirstdrc.org/user/.well-known/openid-configuration
+USER_NAME_PATH_EXPR=/context/user/name
+FENCE_BASE_URL=https://data.kidsfirstdrc.org
+
 {{else}}
 # Non-production environments
 [fence]
@@ -68,6 +75,13 @@ CLIENT_SECRET={{ $secrets.Data.anvil_secret }}
 OPEN_ID_CONFIG_URL=https://staging.theanvil.io/user/.well-known/openid-configuration
 USER_NAME_PATH_EXPR=/context/user/name
 FENCE_BASE_URL=https://staging.theanvil.io/
+
+[kids-first]
+CLIENT_ID={{ $secrets.Data.kids_first_client_id }}
+CLIENT_SECRET={{ $secrets.Data.kids_first_client_id }}
+OPEN_ID_CONFIG_URL=https://gen3staging.kidsfirstdrc.org/user/.well-known/openid-configuration
+USER_NAME_PATH_EXPR=/context/user/name
+FENCE_BASE_URL=https://gen3staging.kidsfirstdrc.org/
 
 {{end}}
 

--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -47,7 +47,7 @@ FENCE_BASE_URL=https://gen3.theanvil.io/
 
 [kids-first]
 CLIENT_ID={{ $secrets.Data.kids_first_client_id }}
-CLIENT_SECRET={{ $secrets.Data.kids_first_client_id }}
+CLIENT_SECRET={{ $secrets.Data.kids_first_client_secret }}
 OPEN_ID_CONFIG_URL=https://data.kidsfirstdrc.org/user/.well-known/openid-configuration
 USER_NAME_PATH_EXPR=/context/user/name
 FENCE_BASE_URL=https://data.kidsfirstdrc.org
@@ -78,7 +78,7 @@ FENCE_BASE_URL=https://staging.theanvil.io/
 
 [kids-first]
 CLIENT_ID={{ $secrets.Data.kids_first_client_id }}
-CLIENT_SECRET={{ $secrets.Data.kids_first_client_id }}
+CLIENT_SECRET={{ $secrets.Data.kids_first_client_secret }}
 OPEN_ID_CONFIG_URL=https://gen3staging.kidsfirstdrc.org/user/.well-known/openid-configuration
 USER_NAME_PATH_EXPR=/context/user/name
 FENCE_BASE_URL=https://gen3staging.kidsfirstdrc.org/


### PR DESCRIPTION
Ticket: [CA-1291](https://broadworkbench.atlassian.net/browse/CA-1291)
Add KidsFirst as a provider to the config. Will need to update vault with the client secrets before merging

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary. 
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
