### PR TITLE
CA-1341 dpath should ALLOW_EMPTY_STRING_KEYS

### DIFF
--- a/bond_app/jwt_token.py
+++ b/bond_app/jwt_token.py
@@ -1,6 +1,7 @@
 import jwt
 from datetime import datetime
 import dpath.util
+import dpath.options
 
 
 class JwtToken:
@@ -11,5 +12,7 @@ class JwtToken:
         :param user_name_path_expr: forward slash delimited path to user name within JWT
         """
         self.raw_dict = jwt.decode(encoded_str, verify=False)
+        # See https://broadworkbench.atlassian.net/browse/CA-1341, needed for dpath to work when dict has "" keys
+        dpath.options.ALLOW_EMPTY_STRING_KEYS = True
         self.username = dpath.util.get(self.raw_dict, user_name_path_expr)
         self.issued_at = datetime.fromtimestamp(self.raw_dict.get('iat'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests-oauthlib==1.3.0
 requests-toolbelt==0.8.0
 pyjwt==1.6.4
 mock==2.0.0
-dpath==1.4.2
+dpath==2.0.1
 google-auth==1.24.0
 google-cloud-core==1.5.0
 google-cloud-logging==2.0.2

--- a/tests/unit/jwt_token_test.py
+++ b/tests/unit/jwt_token_test.py
@@ -1,4 +1,6 @@
 import unittest
+
+import dpath.exceptions
 import jwt
 from bond_app.jwt_token import JwtToken
 from datetime import datetime
@@ -6,11 +8,22 @@ from datetime import datetime
 
 class JwtTokenTestCase(unittest.TestCase):
 
-    def test_init(self):
-        name = "Bob McBob"
-        issued_at = 1528896868
-        data = {"context": {"user": {"name": name}}, 'iat': issued_at}
-        encoded = jwt.encode(data, 'secret', 'HS256')
-        jwt_token = JwtToken(encoded, "/context/user/name")
-        self.assertEqual(name, jwt_token.username)
-        self.assertEqual(datetime.fromtimestamp(issued_at), jwt_token.issued_at)
+    def setUp(self):
+        self.name = "Bob McBob"
+        self.issued_at = 1528896868
+        self.data = {"context": {"user": {"name": self.name}}, 'iat': self.issued_at}
+
+    def encoded(self):
+        return jwt.encode(self.data, 'secret', 'HS256')
+
+    def jwt_token(self):
+        return JwtToken(self.encoded(), "/context/user/name")
+
+    def test_constructor(self):
+        bond_jwt_token = self.jwt_token()
+        self.assertEqual(self.name, bond_jwt_token.username)
+        self.assertEqual(datetime.fromtimestamp(self.issued_at), bond_jwt_token.issued_at)
+
+    def test_jwt_with_empty_key(self):
+        self.data[''] = 'dict entry with empty key'
+        self.test_constructor()


### PR DESCRIPTION
Updating the dpath lib and adding dpath option to ALLOW_EMPTY_STRING_KEYS

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
