### PR TITLE
CA-1376 bumping Flask-CORS dependency from 3.0.8 to 3.0.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,6 @@ webargs==5.5.3
 grpcio==1.34.0
 protorpc==0.12.0
 gunicorn==20.0.4
-flask-cors==3.0.8
+flask-cors==3.0.10
 flask-swagger-ui==3.20.9
 PyYaml==5.4


### PR DESCRIPTION
Addresses: https://github.com/DataBiosphere/bond/security/dependabot/requirements.txt/Flask-Cors/open

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
