### PR TITLE
[BT-622] Cache access tokens

### DIFF
--- a/bond_app/bond.py
+++ b/bond_app/bond.py
@@ -106,16 +106,18 @@ class Bond:
                 expires_at = cached_access_entry.expires_at
                 access_token = cached_access_entry.value
                 expires_in = (expires_at - datetime.now()).total_seconds()
-                logging.info(
-                    f"Retrieved access token from cache. "
-                    f"Cache will be refreshed in {expires_in - refresh_threshold:.2f} seconds."
+                logging.debug(
+                    "Retrieved access token from cache. " +
+                    f"Access token will expire in {expires_in - refresh_threshold:.2f} seconds. " +
+                    f"SAM user ID: {sam_user_id}. Provider: {self.provider_name}"
                 )
             else:
                 access_token, expires_at = self.generate_access_token(sam_user_id, refresh_token=refresh_token)
                 expires_in = (expires_at - datetime.now()).total_seconds()
-                logging.info(
-                    f"Generated new access token. "
-                    f"Cache will be refreshed in {expires_in - refresh_threshold:.2f} seconds."
+                logging.debug(
+                    "Generated new access token. " +
+                    f"Access token will expire in {expires_in - refresh_threshold:.2f} seconds. " +
+                    f"SAM user ID: {sam_user_id}. Provider: {self.provider_name}"
                 )
                 
                 self.cache_api.add(

--- a/bond_app/bond.py
+++ b/bond_app/bond.py
@@ -98,7 +98,7 @@ class Bond:
         """
         refresh_token = self.refresh_token_store.lookup(sam_user_id, self.provider_name)
         if refresh_token is not None:
-            cached_access_data = self.cache_api.get(namespace="AccessTokens", key=sam_user_id)
+            cached_access_data = self.cache_api.get(namespace=f"{self.provider_name}:AccessTokens", key=sam_user_id)
             if cached_access_data and cached_access_data.get(FenceKeys.ACCESS_TOKEN):
                 expires_at = cached_access_data.get(FenceKeys.EXPIRES_AT)
                 access_token = cached_access_data.get(FenceKeys.ACCESS_TOKEN)
@@ -118,7 +118,7 @@ class Bond:
                 )
                 
                 self.cache_api.add(
-                    namespace="AccessTokens", 
+                    namespace=f"{self.provider_name}:AccessTokens", 
                     key=sam_user_id, 
                     value={
                         FenceKeys.EXPIRES_AT: expires_at,

--- a/bond_app/bond.py
+++ b/bond_app/bond.py
@@ -63,9 +63,11 @@ class Bond:
 
     def generate_access_token(self, sam_user_id, refresh_token=None):
         """
-        Given a user, lookup their refresh token (if not provided) and use it to generate a new refresh token (<-should this be "access token"?) from their OAuth
+        Given a user, lookup their refresh token (if not provided) and use it to generate a new access token from their OAuth
         provider.  If a refresh token cannot be found for the sam_user_id provided, a NotFound will be raised.
         :param sam_user_id: Id stored in Sam for user who initiated request
+        :param refresh_token: a refresh token (optional). 
+        If not present, the refresh token will be found using the "sam_user_id" parameter.
         :return: Two values: An Access Token string, datetime when that token expires
         """
         refresh_token = refresh_token or self.refresh_token_store.lookup(sam_user_id, self.provider_name)
@@ -81,6 +83,19 @@ class Bond:
 
 
     def get_access_token(self, sam_user_id, refresh_token=None, refresh_threshold: int = 600):
+        """
+        Given a user, lookup their refresh token (if not provided) and use it to retrieve an access token from their OAuth
+        provider.
+        If an access token was already generated for the user, 
+        and that token has greater than `refresh_threshold` seconds before expiration, return that token. 
+        Otherwise, generate a new token.
+        
+        If a refresh token cannot be found for the sam_user_id provided, a NotFound will be raised.
+        :param sam_user_id: Id stored in Sam for user who initiated request
+        :param refresh_token: a refresh token (optional). 
+        If not present, the refresh token will be found using the "sam_user_id" parameter.
+        :return: Two values: An Access Token string, datetime when that token expires
+        """
         refresh_token = refresh_token or self.refresh_token_store.lookup(sam_user_id, self.provider_name)
         if refresh_token is not None:
             cached_access_entry = self.fence_tvm.cache_api.get_entry(namespace="AccessTokens", key=sam_user_id)

--- a/bond_app/bond.py
+++ b/bond_app/bond.py
@@ -86,7 +86,7 @@ class Bond:
 
     def get_access_token(self, sam_user_id, refresh_threshold: int = 600):
         """
-        Given a user, lookup their refresh token (if not provided) and use it to retrieve an access token from their OAuth
+        Given a user, lookup their refresh token and use it to retrieve an access token from their OAuth
         provider.
         If an access token was already generated for the user, 
         and that token has greater than `refresh_threshold` seconds before expiration, return that token. 

--- a/bond_app/bond.py
+++ b/bond_app/bond.py
@@ -82,7 +82,7 @@ class Bond:
                     sam_user_id, self.provider_name))
 
 
-    def get_access_token(self, sam_user_id, refresh_token=None, refresh_threshold: int = 600):
+    def get_access_token(self, sam_user_id, refresh_threshold: int = 600):
         """
         Given a user, lookup their refresh token (if not provided) and use it to retrieve an access token from their OAuth
         provider.
@@ -92,11 +92,9 @@ class Bond:
         
         If a refresh token cannot be found for the sam_user_id provided, a NotFound will be raised.
         :param sam_user_id: Id stored in Sam for user who initiated request
-        :param refresh_token: a refresh token (optional). 
-        If not present, the refresh token will be found using the "sam_user_id" parameter.
         :return: Two values: An Access Token string, datetime when that token expires
         """
-        refresh_token = refresh_token or self.refresh_token_store.lookup(sam_user_id, self.provider_name)
+        refresh_token = self.refresh_token_store.lookup(sam_user_id, self.provider_name)
         if refresh_token is not None:
             cached_access_entry = self.fence_tvm.cache_api.get_entry(namespace="AccessTokens", key=sam_user_id)
             if (

--- a/bond_app/bond.py
+++ b/bond_app/bond.py
@@ -72,11 +72,11 @@ class Bond:
         If not present, the refresh token will be found using the "sam_user_id" parameter.
         :return: Two values: An Access Token string, datetime when that token expires
         """
+
         refresh_token = refresh_token or self.refresh_token_store.lookup(sam_user_id, self.provider_name)
         if refresh_token is not None:
             token_response = self.oauth_adapter.refresh_access_token(refresh_token.token)
             expires_at = datetime.fromtimestamp(token_response.get(FenceKeys.EXPIRES_AT))
-
             return token_response.get("access_token"), expires_at
         else:
             raise exceptions.NotFound(
@@ -107,17 +107,16 @@ class Bond:
                 access_token_value = access_token.value
                 logging.debug(
                     "Retrieved access token from cache. " +
-                    f"Access token will expire at {expires_at:.2f}. " +
+                    f"Access token will expire at {expires_at}. " +
                     f"SAM user ID: {sam_user_id}. Provider: {self.provider_name}"
                 )
             else:
                 access_token_value, expires_at = self.generate_access_token(sam_user_id, refresh_token=refresh_token)
                 logging.debug(
                     "Generated new access token. " +
-                    f"Access token will expire at {expires_at:.2f} seconds. " +
+                    f"Access token will expire at {expires_at} seconds. " +
                     f"SAM user ID: {sam_user_id}. Provider: {self.provider_name}"
                 )
-                
                 self.cache_api.add(
                     namespace=f"{self.provider_name}:AccessTokens", 
                     key=sam_user_id, 

--- a/bond_app/bond.py
+++ b/bond_app/bond.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 import logging
 from .jwt_token import JwtToken
 

--- a/bond_app/bond.py
+++ b/bond_app/bond.py
@@ -102,18 +102,16 @@ class Bond:
             if cached_access_data and cached_access_data.get(FenceKeys.ACCESS_TOKEN):
                 expires_at = cached_access_data.get(FenceKeys.EXPIRES_AT)
                 access_token = cached_access_data.get(FenceKeys.ACCESS_TOKEN)
-                expires_in_cache = (expires_at - datetime.now()).total_seconds() - refresh_threshold
                 logging.debug(
                     "Retrieved access token from cache. " +
-                    f"Access token will expire in {expires_in_cache:.2f} seconds. " +
+                    f"Access token will expire at {expires_at:.2f}. " +
                     f"SAM user ID: {sam_user_id}. Provider: {self.provider_name}"
                 )
             else:
                 access_token, expires_at = self.generate_access_token(sam_user_id, refresh_token=refresh_token)
-                expires_in_cache = (expires_at - datetime.now()).total_seconds() - refresh_threshold
                 logging.debug(
                     "Generated new access token. " +
-                    f"Access token will expire in {expires_in_cache:.2f} seconds. " +
+                    f"Access token will expire at {expires_at:.2f} seconds. " +
                     f"SAM user ID: {sam_user_id}. Provider: {self.provider_name}"
                 )
                 
@@ -124,7 +122,7 @@ class Bond:
                         FenceKeys.EXPIRES_AT: expires_at,
                         FenceKeys.ACCESS_TOKEN: access_token,
                     },
-                    expires_in=expires_in_cache,
+                    expires_in=(expires_at - datetime.now()).total_seconds() - refresh_threshold,
                 )
             return access_token, expires_at
         else:

--- a/bond_app/bond.py
+++ b/bond_app/bond.py
@@ -9,6 +9,7 @@ class Bond:
     def __init__(self,
                  oauth_adapter,
                  fence_api,
+                 cache_api,
                  refresh_token_store,
                  fence_tvm,
                  provider_name,
@@ -17,6 +18,7 @@ class Bond:
 
         self.oauth_adapter = oauth_adapter
         self.fence_api = fence_api
+        self.cache_api = cache_api
         self.refresh_token_store = refresh_token_store
         self.fence_tvm = fence_tvm
         self.provider_name = provider_name
@@ -96,7 +98,7 @@ class Bond:
         """
         refresh_token = self.refresh_token_store.lookup(sam_user_id, self.provider_name)
         if refresh_token is not None:
-            cached_access_entry = self.fence_tvm.cache_api.get_entry(namespace="AccessTokens", key=sam_user_id)
+            cached_access_entry = self.cache_api.get_entry(namespace="AccessTokens", key=sam_user_id)
             if (
                 cached_access_entry and 
                 cached_access_entry.expires_at - datetime.now() > timedelta(seconds=refresh_threshold)
@@ -116,7 +118,7 @@ class Bond:
                     f"Cache will be refreshed in {expires_in - refresh_threshold:.2f} seconds."
                 )
                 
-                self.fence_tvm.cache_api.add(
+                self.cache_api.add(
                     namespace="AccessTokens", 
                     key=sam_user_id, 
                     value=access_token,

--- a/bond_app/datastore_cache_api.py
+++ b/bond_app/datastore_cache_api.py
@@ -29,15 +29,11 @@ class DatastoreCacheApi(CacheApi):
                    expires_at=DatastoreCacheApi._calculate_expiration(expires_in)).put()
         return True
 
-    def get_entry(self, key, namespace=None):
+    def get(self, key, namespace=None):
         entry = DatastoreCacheApi._build_cache_key(key, namespace).get()
         if not entry or entry.expires_at < datetime.datetime.now():
             return None
-        return entry
-
-    def get(self, key, namespace=None):
-        entry = self.get_entry(key, namespace=namespace)
-        return entry.value if hasattr(entry, "value") else None
+        return entry.value
 
     def delete(self, key, namespace=None):
         DatastoreCacheApi._build_cache_key(key, namespace).delete()

--- a/bond_app/datastore_cache_api.py
+++ b/bond_app/datastore_cache_api.py
@@ -29,11 +29,15 @@ class DatastoreCacheApi(CacheApi):
                    expires_at=DatastoreCacheApi._calculate_expiration(expires_in)).put()
         return True
 
-    def get(self, key, namespace=None):
+    def get_entry(self, key, namespace=None):
         entry = DatastoreCacheApi._build_cache_key(key, namespace).get()
         if not entry or entry.expires_at < datetime.datetime.now():
             return None
-        return entry.value
+        return entry
+
+    def get(self, key, namespace=None):
+        entry = self.get_entry(key, namespace=namespace)
+        return entry.value if hasattr(entry, "value") else None
 
     def delete(self, key, namespace=None):
         DatastoreCacheApi._build_cache_key(key, namespace).delete()

--- a/bond_app/routes.py
+++ b/bond_app/routes.py
@@ -185,7 +185,7 @@ def delete_link(provider):
 @routes.route(v1_link_route_base + '/<provider>/accesstoken', methods=["GET"])
 def accesstoken(provider):
     sam_user_id = auth.auth_user(request)
-    access_token, expires_at = _get_provider(provider).bond.generate_access_token(sam_user_id)
+    access_token, expires_at = _get_provider(provider).bond.get_access_token(sam_user_id)
     return json_response(AccessTokenResponse(token=access_token, expires_at=expires_at))
 
 

--- a/bond_app/routes.py
+++ b/bond_app/routes.py
@@ -109,6 +109,7 @@ def create_provider(provider_name):
                                          provider_name, fence_token_storage.FenceTokenStorage())
     return BondProvider(fence_tvm, Bond(oauth_adapter,
                                         fence_api,
+                                        cache_api,
                                         refresh_token_store,
                                         fence_tvm,
                                         provider_name,

--- a/tests/unit/bond_test.py
+++ b/tests/unit/bond_test.py
@@ -151,7 +151,7 @@ class BondTestCase(unittest.TestCase):
                                       username=self.name,
                                       provider_name=provider_name)
 
-        # verify that the new `expired_at` value is returned with `get_access_token`,
+        # verify that the new `expires_at` value is returned with `get_access_token`,
         # when nothing has been cached yet.
         access_token, expires_at = bond.get_access_token(self.user_id, refresh_threshold=0)
         self.assertEqual(self.fake_access_token, access_token)

--- a/tests/unit/bond_test.py
+++ b/tests/unit/bond_test.py
@@ -151,8 +151,8 @@ class BondTestCase(unittest.TestCase):
                                       username=self.name,
                                       provider_name=provider_name)
 
-        # verify that the new `expires_at` value is returned with `get_access_token`,
-        # when nothing has been cached yet.
+        # verify that the `expires_at_initial` value is returned with `get_access_token`,
+        # because nothing has been cached yet.
         access_token, expires_at = bond.get_access_token(self.user_id, refresh_threshold=0)
         self.assertEqual(self.fake_access_token, access_token)
         self.assertEqual(datetime.fromtimestamp(expires_at_initial), expires_at)
@@ -207,7 +207,7 @@ class BondTestCase(unittest.TestCase):
                                       username=self.name,
                                       provider_name=provider_name)
 
-        # verify that the old `expired_at_initial` value is returned with `get_access_token`,
+        # verify that the `expires_at_initial` value is returned with `get_access_token`,
         # because nothing has been cached yet.
         access_token, expires_at = bond.get_access_token(self.user_id, refresh_threshold=refresh_threshold)
         self.assertEqual(self.fake_access_token, access_token)

--- a/tests/unit/bond_test.py
+++ b/tests/unit/bond_test.py
@@ -46,6 +46,7 @@ class BondTestCase(unittest.TestCase):
         self.refresh_token_store = FakeTokenStore()
         self.bond = Bond(mock_oauth_adapter,
                          fence_api,
+                         FakeCacheApi(),
                          self.refresh_token_store,
                          FenceTokenVendingMachine(fence_api, FakeCacheApi(), self.refresh_token_store,
                                                   mock_oauth_adapter,
@@ -74,6 +75,7 @@ class BondTestCase(unittest.TestCase):
         fence_api = self._mock_fence_api(json.dumps({"private_key_id": "asfasdfasdf"}))
         bond = Bond(mock_oauth_adapter,
                     fence_api,
+                    FakeCacheApi(),
                     self.refresh_token_store,
                     FenceTokenVendingMachine(fence_api, FakeCacheApi(), self.refresh_token_store,
                                              mock_oauth_adapter, provider_name,


### PR DESCRIPTION
Caches access tokens using the existing Datastore cache API. Builds upon https://github.com/DataBiosphere/bond/pull/178

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
