### PR TITLE
[DDO-2062] Add ability to point at Sam in k8s

### DIFF
--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -89,7 +89,7 @@ FENCE_BASE_URL=https://gen3staging.kidsfirstdrc.org/
 [sam]
 {{- if $samUrl -}}
 BASE_URL={{ $samUrl }}
-{{- else -}
+{{- else -}}
 BASE_URL={{if eq $runContext "fiab"}}https://sam-fiab.{{$dnsDomain}}{{else}}https://sam.dsde-{{$environment}}.broadinstitute.org{{end}}
 {{- end -}}
 

--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -87,11 +87,7 @@ FENCE_BASE_URL=https://gen3staging.kidsfirstdrc.org/
 {{end}}
 
 [sam]
-{{ if $samUrl -}}
-BASE_URL={{ $samUrl }}
-{{- else -}}
-BASE_URL={{if eq $runContext "fiab"}}https://sam-fiab.{{$dnsDomain}}{{else}}https://sam.dsde-{{$environment}}.broadinstitute.org{{end}}
-{{- end }}
+BASE_URL={{ if $samUrl }}{{ $samUrl }}{{else if eq $runContext "fiab"}}https://sam-fiab.{{$dnsDomain}}{{else}}https://sam.dsde-{{$environment}}.broadinstitute.org{{end}}
 
 
 [bond_accepted]

--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -91,7 +91,7 @@ FENCE_BASE_URL=https://gen3staging.kidsfirstdrc.org/
 BASE_URL={{ $samUrl }}
 {{- else -}}
 BASE_URL={{if eq $runContext "fiab"}}https://sam-fiab.{{$dnsDomain}}{{else}}https://sam.dsde-{{$environment}}.broadinstitute.org{{end}}
-{{- end -}}
+{{- end }}
 
 
 [bond_accepted]

--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -3,6 +3,7 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 {{with $secrets := secret (printf "secret/dsde/bond/%s/config.ini" $environment)}}
 {{with $commonSecrets := secret (printf "secret/dsde/firecloud/common/oauth_client_id")}}
+{{- $samUrl := env "SAM_URL" -}}
 
 {{if (or (eq $runContext "fiab") (eq $runContext "local")) }}
 # fiab settings are mock providers
@@ -86,7 +87,11 @@ FENCE_BASE_URL=https://gen3staging.kidsfirstdrc.org/
 {{end}}
 
 [sam]
+{{- if $samUrl -}}
+BASE_URL={{ $samUrl }}
+{{- else -}
 BASE_URL={{if eq $runContext "fiab"}}https://sam-fiab.{{$dnsDomain}}{{else}}https://sam.dsde-{{$environment}}.broadinstitute.org{{end}}
+{{- end -}}
 
 
 [bond_accepted]

--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -87,7 +87,7 @@ FENCE_BASE_URL=https://gen3staging.kidsfirstdrc.org/
 {{end}}
 
 [sam]
-{{- if $samUrl -}}
+{{ if $samUrl -}}
 BASE_URL={{ $samUrl }}
 {{- else -}}
 BASE_URL={{if eq $runContext "fiab"}}https://sam-fiab.{{$dnsDomain}}{{else}}https://sam.dsde-{{$environment}}.broadinstitute.org{{end}}


### PR DESCRIPTION
As a part of the BEEs project, I added this tiny diff to allow for Bond to configured to point at a custom Sam URL, which for us will be Sam running in k8s in a BEE.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [X] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [N/A] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [N/A] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary. 
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
