### PR TITLE
[TOAZ-132] Update bond to support B2C authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ crashlytics-build.properties
 automation/report.xml
 
 /env3/
+
+.vscode

--- a/bond_app/jwt_token.py
+++ b/bond_app/jwt_token.py
@@ -11,7 +11,7 @@ class JwtToken:
         :param encoded_str: encoded JWT
         :param user_name_path_expr: forward slash delimited path to user name within JWT
         """
-        self.raw_dict = jwt.decode(encoded_str, verify=False)
+        self.raw_dict = jwt.decode(encoded_str, options={'verify_signature': False})
         # See https://broadworkbench.atlassian.net/browse/CA-1341, needed for dpath to work when dict has "" keys
         dpath.options.ALLOW_EMPTY_STRING_KEYS = True
         self.username = dpath.util.get(self.raw_dict, user_name_path_expr)

--- a/bond_app/routes.py
+++ b/bond_app/routes.py
@@ -142,7 +142,9 @@ sam_base_url = config.get('sam', 'BASE_URL')
 sam_api = SamApi(sam_base_url)
 authentication_config = authentication.AuthenticationConfig(config.get('bond_accepted', 'AUDIENCE_PREFIXES').split(),
                                                             config.get('bond_accepted', 'EMAIL_SUFFIXES').split(),
-                                                            os.environ.get('BOND_MAX_TOKEN_LIFE', 600))
+                                                            os.environ.get('BOND_MAX_TOKEN_LIFE', 600),
+                                                            config.get('bond_accepted', 'B2C_AUTHORITY_ENDPOINT'),
+                                                            config.get('bond_accepted', 'B2C_AUDIENCE'))
 auth = authentication.Authentication(authentication_config, cache_api, sam_api)
 
 api_version = 'v1'

--- a/bond_app/routes.py
+++ b/bond_app/routes.py
@@ -143,8 +143,8 @@ sam_api = SamApi(sam_base_url)
 authentication_config = authentication.AuthenticationConfig(config.get('bond_accepted', 'AUDIENCE_PREFIXES').split(),
                                                             config.get('bond_accepted', 'EMAIL_SUFFIXES').split(),
                                                             os.environ.get('BOND_MAX_TOKEN_LIFE', 600),
-                                                            config.get('bond_accepted', 'B2C_AUTHORITY_ENDPOINT'),
-                                                            config.get('bond_accepted', 'B2C_AUDIENCE'))
+                                                            config.get('bond_accepted', 'OIDC_AUTHORITY_ENDPOINT'),
+                                                            config.get('bond_accepted', 'OIDC_AUDIENCE'))
 auth = authentication.Authentication(authentication_config, cache_api, sam_api)
 
 api_version = 'v1'

--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -3,6 +3,7 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 {{with $secrets := secret (printf "secret/dsde/bond/%s/config.ini" $environment)}}
 {{with $commonSecrets := secret (printf "secret/dsde/firecloud/common/oauth_client_id")}}
+{{with $b2cApplicationId := secret (printf "secret/dsde/terra/azure/%s/b2c/application_id" $environment)}}
 {{- $samUrl := env "SAM_URL" -}}
 
 {{if (or (eq $runContext "fiab") (eq $runContext "local")) }}
@@ -93,5 +94,9 @@ BASE_URL={{ if $samUrl }}{{ $samUrl }}{{else if eq $runContext "fiab"}}https://s
 [bond_accepted]
 AUDIENCE_PREFIXES={{range $index, $element := $commonSecrets.Data.client_ids}} {{ $element }}{{end}}
 EMAIL_SUFFIXES=.gserviceaccount.com
+{{ if ne $environment "prod" }}
+B2C_AUTHORITY_ENDPOINT=https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN/v2.0
+B2C_AUDIENCE={{ $b2cApplicationId.Data.value }}
+{{ end }}
 
-{{end}}{{end}}{{end}}{{end}}{{end}}
+{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}

--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -95,8 +95,8 @@ BASE_URL={{ if $samUrl }}{{ $samUrl }}{{else if eq $runContext "fiab"}}https://s
 AUDIENCE_PREFIXES={{range $index, $element := $commonSecrets.Data.client_ids}} {{ $element }}{{end}}
 EMAIL_SUFFIXES=.gserviceaccount.com
 {{ if ne $environment "prod" }}
-B2C_AUTHORITY_ENDPOINT=https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN/v2.0
-B2C_AUDIENCE={{ $b2cApplicationId.Data.value }}
+OIDC_AUTHORITY_ENDPOINT=https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN/v2.0
+OIDC_AUDIENCE={{ $b2cApplicationId.Data.value }}
 {{ end }}
 
 {{end}}{{end}}{{end}}{{end}}{{end}}{{end}}

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ flask-swagger-ui==3.20.9
 PyYaml==5.4
 jinja2==3.0.3
 itsdangerous==2.0.1
+http-server-mock==1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ PyYaml==5.4
 jinja2==3.0.3
 itsdangerous==2.0.1
 http-server-mock==1.7
+cryptography==37.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ jsonschema==3.2.0
 requests==2.20.0
 requests-oauthlib==1.3.0
 requests-toolbelt==0.8.0
-pyjwt==1.6.4
+pyjwt==2.4.0
 mock==2.0.0
 dpath==2.0.1
 google-auth==1.24.0

--- a/tests/unit/authentication_test.py
+++ b/tests/unit/authentication_test.py
@@ -2,18 +2,51 @@ import unittest
 
 from werkzeug import exceptions
 from mock import MagicMock
+from http_server_mock import HttpServerMock
+from cryptography.hazmat.primitives.asymmetric import rsa
+import json
+import jwt
+from jwt.utils import to_base64url_uint
+import time
 
 from bond_app.authentication import Authentication, AuthenticationConfig, UserInfo
 from bond_app.sam_api import SamApi, SamKeys
 from tests.unit.fake_cache_api import FakeCacheApi
-import json
 
+ALGORITHM = "RS256"
+PUBLIC_KEY_ID = "sample-key-id"
 
 class TestRequestState:
     def __init__(self, auth_header):
         self.headers = {}
         if auth_header is not None:
             self.headers['Authorization'] = auth_header
+
+class MockOidcServer:
+    def __init__(self, public_key):
+        super().__init__()
+        self.app = HttpServerMock(__name__)
+        self.public_key = public_key
+        public_numbers = public_key.public_numbers()
+
+        @self.app.route("/.well-known/openid-configuration", methods=["GET"])
+        def metadata():
+            return json.dumps({'jwks_uri': 'http://localhost:5000/keys'})
+
+        @self.app.route("/keys", methods=["GET"])
+        def jwks():
+            return json.dumps({
+                'keys': [
+                    {
+                        'kid': PUBLIC_KEY_ID,
+                        'alg': ALGORITHM,
+                        'kty': "RSA",
+                        'use': "sig",
+                        'n': to_base64url_uint(public_numbers.n).decode("ascii"),
+                        'e': to_base64url_uint(public_numbers.e).decode("ascii")
+                    }
+                ]
+            })
 
 
 class AuthenticationTestCase(unittest.TestCase):
@@ -22,6 +55,9 @@ class AuthenticationTestCase(unittest.TestCase):
         self.cache_api = FakeCacheApi()
         self.sam_api = SamApi("")
         self.auth = Authentication(AuthenticationConfig( ['32555940559'], ['.gserviceaccount.com'], 600), self.cache_api, self.sam_api)
+        self.private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        self.public_key = self.private_key.public_key()
+        self.mock_server = MockOidcServer(self.public_key)
 
     def test_good_user_no_cached_info(self):
         token = "testtoken"
@@ -292,18 +328,77 @@ class AuthenticationTestCase(unittest.TestCase):
         }
         self._unauthorized_test(token_data)
 
-    def test_retrieve_b2c_metadata(self):
-        auth = Authentication(
-            AuthenticationConfig(
-                ['32555940559'], 
-                ['.gserviceaccount.com'], 
-                600,
-                'https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN/v2.0',
-                'bbd07d43-01cb-4b69-8fd0-5746d9a5c9fe'
-            ), self.cache_api, self.sam_api)
-        self.assertEqual(
-            "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/discovery/v2.0/keys", 
-            auth.config.jwks_uri)
+    def test_valid_jwt(self):
+        audience = 'my-test-audience'
+        epoch_time = int(time.time())
+        token_data = {
+            "aud": audience,
+            "sub": "my-sub",
+            "exp": epoch_time + 300,
+            "iat": epoch_time,
+            "email": "fake@email.com"
+        }
+        token = self._encode_token(token_data)
+        expected_user_info = UserInfo("193481341723041", "foo@bar.com", token, 100)
+        self.sam_api.user_info = MagicMock(
+            return_value=self._generate_sam_user_info(expected_user_info.id, expected_user_info.email, True))
+        with self.mock_server.app.run("localhost", 5000):
+            auth = Authentication(
+                AuthenticationConfig([], [], 600,
+                    'http://localhost:5000',
+                    audience
+                ), self.cache_api, self.sam_api)
+            sam_user_id = auth.auth_user(TestRequestState('bearer ' + token))
+            self.assertEqual(expected_user_info.id, sam_user_id)
+
+    def test_jwt_invalid_audience(self):
+        epoch_time = int(time.time())
+        token_data = {
+            "aud": "bad-audience",
+            "sub": "my-sub",
+            "exp": epoch_time + 300,
+            "iat": epoch_time,
+            "email": "fake@email.com"
+        }
+        token = self._encode_token(token_data)
+        with self.mock_server.app.run("localhost", 5000):
+            auth = Authentication(
+                AuthenticationConfig([], [], 600,
+                    'http://localhost:5000',
+                    'good-audience'
+                ), self.cache_api, self.sam_api)
+            with self.assertRaises(exceptions.Unauthorized):
+                auth.auth_user(TestRequestState('bearer ' + token))
+
+    def test_jwt_fallback_to_google(self):
+        with self.mock_server.app.run("localhost", 5000):
+            token = "testtoken"
+            expected_user_info = UserInfo("193481341723041", "foo@bar.com", token, 100)
+            self.sam_api.user_info = MagicMock(
+                return_value=self._generate_sam_user_info(expected_user_info.id, expected_user_info.email, True))
+
+            def token_fn(token):
+                token_data = {
+                    "audience": "32555940559.apps.googleusercontent.com",
+                    "user_id": expected_user_info.id,
+                    "expires_in": expected_user_info.expires_in,
+                    "email": expected_user_info.email,
+                    "verified_email": True
+                }
+                return json.dumps(token_data)
+
+            sam_user_id = self.auth.auth_user(TestRequestState('bearer ' + token), token_fn)
+            self.assertEqual(expected_user_info.id, sam_user_id)
 
     def _generate_sam_user_info(self, user_id, email, enabled):
         return {SamKeys.USER_ID_KEY: user_id, SamKeys.USER_EMAIL_KEY: email, SamKeys.USER_ENABLED_KEY: enabled}
+
+    def _encode_token(self, payload):
+        return jwt.encode(
+            payload=payload,
+            key=self.private_key,
+            algorithm='RS256',
+            headers={
+                'kid': PUBLIC_KEY_ID,
+            }
+        )

--- a/tests/unit/authentication_test.py
+++ b/tests/unit/authentication_test.py
@@ -54,7 +54,8 @@ class AuthenticationTestCase(unittest.TestCase):
     def setUp(self):
         self.cache_api = FakeCacheApi()
         self.sam_api = SamApi("")
-        self.auth = Authentication(AuthenticationConfig( ['32555940559'], ['.gserviceaccount.com'], 600), self.cache_api, self.sam_api)
+        self.auth = Authentication(AuthenticationConfig( ['32555940559'], ['.gserviceaccount.com'], 600), 
+                                   self.cache_api, self.sam_api)
         self.private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
         self.public_key = self.private_key.public_key()
         self.mock_server = MockOidcServer(self.public_key)

--- a/tests/unit/authentication_test.py
+++ b/tests/unit/authentication_test.py
@@ -21,8 +21,7 @@ class AuthenticationTestCase(unittest.TestCase):
     def setUp(self):
         self.cache_api = FakeCacheApi()
         self.sam_api = SamApi("")
-        self.auth = Authentication(AuthenticationConfig(['32555940559'], ['.gserviceaccount.com'], 600),
-                                   self.cache_api, self.sam_api)
+        self.auth = Authentication(AuthenticationConfig( ['32555940559'], ['.gserviceaccount.com'], 600), self.cache_api, self.sam_api)
 
     def test_good_user_no_cached_info(self):
         token = "testtoken"
@@ -292,6 +291,19 @@ class AuthenticationTestCase(unittest.TestCase):
             "verified_email": True
         }
         self._unauthorized_test(token_data)
+
+    def test_retrieve_b2c_metadata(self):
+        auth = Authentication(
+            AuthenticationConfig(
+                ['32555940559'], 
+                ['.gserviceaccount.com'], 
+                600,
+                'https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN/v2.0',
+                'bbd07d43-01cb-4b69-8fd0-5746d9a5c9fe'
+            ), self.cache_api, self.sam_api)
+        self.assertEqual(
+            "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/discovery/v2.0/keys", 
+            auth.config.jwks_uri)
 
     def _generate_sam_user_info(self, user_id, email, enabled):
         return {SamKeys.USER_ID_KEY: user_id, SamKeys.USER_EMAIL_KEY: email, SamKeys.USER_ENABLED_KEY: enabled}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-132

Updated bond to support authenticating with B2C tokens, with a fallback to Google tokeninfo. (Most services use the Apache proxy for this, but bond does it in python code. Bond is the last remaining service to be updated 😅 .)

I'm not extremely familiar with bond, but it looks like the user's oauth token is only used to authorize with Sam, and downstream code uses the Sam user id. So I think the scope of these changes should be ok.

Use `pyjwt` library to verify the JWT signature using the jwks endpoint. Also validate that all the claims are valid (sub, aud, iat, exp, email).

Testing performed:
* Added unit tests for JWT authentication
* Existing automation tests passed (with google tokens)
   * It would be nice to add automation tests that use B2C tokens, but we don't have great support for that now so I think it's out of scope of this PR. 
* Deployed to a fiab, tested with a local B2C-enabled Terra UI pointing to the fiab. The calls to bond authenticate successfully but return 404:
   ```
   {"error":{"code":404,"errors":[{"domain":"global","message":"fence link does not exist. Consider re-linking your account.","reason":"notFound"}],"message":"fence link does not exist. Consider re-linking your account."}}
   ```
   This happens for both Google and B2C so I _think_ it's expected? **Q: is there is a better way to test bond with a local Terra UI?**


----
Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
