### PR TITLE
[BT-660] refresh cache upon unlinking

### DIFF
--- a/bond_app/bond.py
+++ b/bond_app/bond.py
@@ -140,6 +140,7 @@ class Bond:
             self.fence_tvm.remove_service_account(sam_user_id)
             self.oauth_adapter.revoke_refresh_token(refresh_token.token)
             self.refresh_token_store.delete(sam_user_id, self.provider_name)
+            self.cache_api.delete(key=sam_user_id, namespace=f"{self.provider_name}:AccessTokens")
         else:
             logging.warning(
                 "Tried to remove user refresh token, but none was found: sam_user_id: {}, provider_name: {}".format(sam_user_id,

--- a/tests/unit/bond_test.py
+++ b/tests/unit/bond_test.py
@@ -319,8 +319,11 @@ class BondTestCase(unittest.TestCase):
         access_token, expires_at = bond.get_access_token(self.user_id)
         self.assertEqual(access_token_initial, access_token)
 
-        # unlink and relink account
+        # unlink account and verify that the access token has been cleared
         bond.unlink_account(self.user_id)
+        self.assertIsNone(cache_api.get(self.user_id, namespace=f"{provider_name}:AccessTokens"))
+
+        # relink account
         self.refresh_token_store.save(
             user_id=self.user_id,
             refresh_token_str=refresh_token_renewed,

--- a/tests/unit/bond_test.py
+++ b/tests/unit/bond_test.py
@@ -248,6 +248,93 @@ class BondTestCase(unittest.TestCase):
         with self.assertRaises(exceptions.NotFound):
             self.bond.fence_tvm.get_service_account_key_json(self.user_id)
 
+    def test_revoke_link_access_token(self):
+        '''
+        Ensures that cached access tokens are dumped when a user unlinks their account.
+        '''
+
+        data = {"context": {"user": {"name": self.name}}, 'iat': self.issued_at_epoch}
+        refresh_token_initial = str(uuid.uuid4())
+        refresh_token_renewed = str(uuid.uuid4())
+        encoded_jwt = jwt.encode(data, 'secret', 'HS256')
+        expires_at = datetime.now().timestamp() + 100000
+        access_token_initial = "access_token_initial"
+        access_token_renewed = "access_token_renewed"
+        
+        fake_token_defaults = {
+            FenceKeys.ACCESS_TOKEN: access_token_initial,
+            FenceKeys.REFRESH_TOKEN: refresh_token_initial,
+            FenceKeys.ID_TOKEN: encoded_jwt,
+            FenceKeys.EXPIRES_AT: expires_at,
+        }
+
+        mock_oauth_adapter = OauthAdapter("foo", "bar", "baz", "qux")
+        mock_oauth_adapter.exchange_authz_code = MagicMock(return_value=fake_token_defaults, name="exchange_authz_code")
+        mock_oauth_adapter.refresh_access_token = MagicMock(return_value=fake_token_defaults, name="refresh_access_token")
+        mock_oauth_adapter.revoke_refresh_token = MagicMock(name="revoke_refresh_token")
+        mock_oauth_adapter.build_authz_url = MagicMock(name="build_authz_url")
+
+        fence_api = self._mock_fence_api(json.dumps({"private_key_id": "asfasdfasdf"}))
+        cache_api = FakeCacheApi()
+        
+        bond = Bond(
+            mock_oauth_adapter,
+            fence_api,
+            cache_api,
+            self.refresh_token_store,
+            FenceTokenVendingMachine(
+                fence_api, 
+                cache_api, 
+                self.refresh_token_store, 
+                mock_oauth_adapter, 
+                provider_name, 
+                FakeFenceTokenStorage(),
+            ),
+            provider_name,
+            "/context/user/name",
+            {},
+        )
+        
+        # link
+        self.refresh_token_store.save(
+            user_id=self.user_id,
+            refresh_token_str=refresh_token_initial,
+            issued_at=datetime.fromtimestamp(self.issued_at_epoch),
+            username=self.name,
+            provider_name=provider_name,
+        )
+        bond.fence_tvm.get_service_account_key_json(self.user_id)
+
+        # generate and cache a token `access_token_initial` by calling `get_access_token`
+        access_token, expires_at = bond.get_access_token(self.user_id)
+        self.assertEqual(access_token_initial, access_token)
+
+        # re-mock refresh_access_token return values to simulate a new access token to be issued
+        mock_oauth_adapter.refresh_access_token = MagicMock(
+            return_value={**fake_token_defaults, **{FenceKeys.ACCESS_TOKEN: access_token_renewed}}, 
+            name="refresh_access_token"
+        )
+
+        # demonstrate that `access_token_initial` has been cached
+        access_token, expires_at = bond.get_access_token(self.user_id)
+        self.assertEqual(access_token_initial, access_token)
+
+        # unlink and relink account
+        bond.unlink_account(self.user_id)
+        self.refresh_token_store.save(
+            user_id=self.user_id,
+            refresh_token_str=refresh_token_renewed,
+            issued_at=datetime.fromtimestamp(self.issued_at_epoch),
+            username=self.name,
+            provider_name=provider_name,
+        )
+        bond.fence_tvm.get_service_account_key_json(self.user_id)
+        
+        # check cache to ensure that it was dumped
+        access_token, expires_at = bond.get_access_token(self.user_id)
+        self.assertEqual(access_token_renewed, access_token)
+
+
     def test_revoke_link_does_not_exists(self):
         self.bond.unlink_account(self.user_id)
 

--- a/tests/unit/bond_test.py
+++ b/tests/unit/bond_test.py
@@ -116,96 +116,60 @@ class BondTestCase(unittest.TestCase):
         self.assertEqual(self.fake_access_token, access_token)
         self.assertEqual(datetime.fromtimestamp(self.expires_at_epoch), expires_at)
 
-    def test_get_access_token_cached(self):
+    def test_get_access_token_from_cache(self):
         data = {"context": {"user": {"name": self.name}}, 'iat': self.issued_at_epoch}
         encoded_jwt = jwt.encode(data, 'secret', 'HS256')
-        refresh_token = str(uuid.uuid4())
-        
         expires_at_initial = datetime.now().timestamp() + 1
-        expires_at_renewed = expires_at_initial + 100
-
-        access_token_initial = "access_token_initial"
-        access_token_renewed = "access_token_renewed"
         
-        fake_tokens_initial = {
-            FenceKeys.ACCESS_TOKEN: access_token_initial,
+        fake_token_defaults = {
+            FenceKeys.ACCESS_TOKEN: self.fake_access_token,
             FenceKeys.ID_TOKEN: encoded_jwt,
-            FenceKeys.REFRESH_TOKEN: refresh_token,
-            FenceKeys.EXPIRES_AT: expires_at_initial,
-        }
-
-        fake_tokens_renewed = {
-            FenceKeys.ACCESS_TOKEN: access_token_renewed,
-            FenceKeys.EXPIRES_AT: expires_at_renewed,
         }
 
         mock_oauth_adapter = OauthAdapter("foo", "bar", "baz", "qux")
-        mock_oauth_adapter.exchange_authz_code = MagicMock(return_value=fake_tokens_initial, name="exchange_authz_code")
-        mock_oauth_adapter.refresh_access_token = MagicMock(return_value=fake_tokens_initial, name="refresh_access_token")
-        mock_oauth_adapter.revoke_refresh_token = MagicMock(name="revoke_refresh_token")
-        mock_oauth_adapter.build_authz_url = MagicMock(name="build_authz_url")
+        mock_oauth_adapter.refresh_access_token = MagicMock(
+            return_value={**fake_token_defaults, **{FenceKeys.EXPIRES_AT: expires_at_initial}}
+        )
 
         fence_api = self._mock_fence_api(json.dumps({"private_key_id": "asfasdfasdf"}))
         cache_api = FakeCacheApi()
-        this_bond = Bond(
-            mock_oauth_adapter,
-            fence_api,
-            cache_api,
-            self.refresh_token_store,
-            FenceTokenVendingMachine(
-                fence_api, 
-                cache_api, 
-                self.refresh_token_store,
-                mock_oauth_adapter, provider_name,
-                FakeFenceTokenStorage()
-            ),
-            provider_name,
-            "/context/user/name",
-            {},
-        )
+        bond = Bond(mock_oauth_adapter,
+                    fence_api,
+                    cache_api,
+                    self.refresh_token_store,
+                    FenceTokenVendingMachine(fence_api, cache_api, self.refresh_token_store,
+                                             mock_oauth_adapter, provider_name,
+                                             FakeFenceTokenStorage()),
+                    provider_name,
+                    "/context/user/name",
+                    {})
+        
+        token = str(uuid.uuid4())
+        self.refresh_token_store.save(user_id=self.user_id,
+                                      refresh_token_str=token,
+                                      issued_at=datetime.fromtimestamp(self.issued_at_epoch),
+                                      username=self.name,
+                                      provider_name=provider_name)
 
-        # link account
-        self.refresh_token_store.save(
-            user_id=self.user_id,
-            refresh_token_str=refresh_token,
-            issued_at=datetime.fromtimestamp(self.issued_at_epoch),
-            username=self.name,
-            provider_name=provider_name,
-        )
-        this_bond.fence_tvm.get_service_account_key_json(self.user_id)
-
-        # request an access token. verify that it has its initial values.
-        access_token, expires_at = this_bond.get_access_token(self.user_id, refresh_threshold=0)
-        self.assertEqual(access_token_initial, access_token)
+        # verify that the `expires_at_initial` value is returned with `get_access_token`,
+        # because nothing has been cached yet.
+        access_token, expires_at = bond.get_access_token(self.user_id, refresh_threshold=0)
+        self.assertEqual(self.fake_access_token, access_token)
         self.assertEqual(datetime.fromtimestamp(expires_at_initial), expires_at)
 
-        # Update the expiration date and token that is returned by the mock oauth adapter,
+        # Update the expiration date of the token that is returned by the mock oauth adapter,
         # simulating the behavior of the real oauth adapter when a new access token is created.
+        # (in reality, the token would be updated too, but it's not necessary for this test)
+        expires_at_new = expires_at_initial + 100
         mock_oauth_adapter.refresh_access_token = MagicMock(
-            return_value={**fake_tokens_initial, **fake_tokens_renewed}
+            return_value={**fake_token_defaults, **{FenceKeys.EXPIRES_AT: expires_at_new}}
         )
 
-        # verify that the cached expiration and token values are returned with `get_access_token`,
-        # *not* the "renewed" values
-        access_token, expires_at = this_bond.get_access_token(self.user_id)
-        self.assertEqual(access_token_initial, access_token)
+        # verify that the cached `expires_at_initial` value is returned with `get_access_token`,
+        # *not* the new `expires_at_new` value.
+        access_token, expires_at = bond.get_access_token(self.user_id)
+        self.assertEqual(self.fake_access_token, access_token)
         self.assertEqual(datetime.fromtimestamp(expires_at_initial), expires_at)
-
-        # unlink and relink account
-        this_bond.unlink_account(self.user_id)
-        self.refresh_token_store.save(
-            user_id=self.user_id,
-            refresh_token_str=refresh_token,
-            issued_at=datetime.fromtimestamp(self.issued_at_epoch),
-            username=self.name,
-            provider_name=provider_name,
-        )
-        this_bond.fence_tvm.get_service_account_key_json(self.user_id)
-        
-        # check cache to ensure that it was dumped after unlinking
-        access_token, expires_at = this_bond.get_access_token(self.user_id)
-        self.assertEqual(access_token_renewed, access_token)
-        
 
     def test_get_access_token_from_generate(self):
         data = {"context": {"user": {"name": self.name}}, 'iat': self.issued_at_epoch}


### PR DESCRIPTION
Previously, cached access tokens were not cleared when the user account is unlinked. This PR fixes that.

This PR has two commits that test the same behavior:
- one commit defines a new unit test, treating this as an independent behavior
- the other adds functionality to the existing access token caching test

Only one of these commits is needed. Personally, I think it makes sense to test this behavior within the existing tests, but I defer to the reviewers' judgment.
 
---

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
