### PR TITLE
[ID-45] update release docs (skip tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ can be reached at the path:
 
 `http://{your_host}/api/docs/`
 
+For example: https://broad-bond-dev.appspot.com/api/docs/
+
 ## Authorization 
 For endpoints that require authorization, you will need a Google Access Token that you can generate using the 
 [gcloud](https://cloud.google.com/sdk/gcloud) command:
@@ -233,6 +235,8 @@ deployment of the `develop` branch will be triggered if anyone commits or pushes
 
 ## Deploy to non-production environments
 
+Note: if you are deploying to non-prod envs as part of a prod release, then skip this section since these instructions are already included in the [Production Deployment Checklist](#production-deployment-checklist).
+
 1. Log in to [Jenkins](https://fc-jenkins.dsp-techops.broadinstitute.org/) 
 1. Navigate to the [bond-manual-deploy](https://fc-jenkins.dsp-techops.broadinstitute.org/view/Indie%20Deploys/job/bond-manual-deploy/)
    job
@@ -243,9 +247,9 @@ deployment of the `develop` branch will be triggered if anyone commits or pushes
 
 ## Production Deployment Checklist
 
+### Create a ticket and load the Bond Release Checklist template
 To perform a release, you are _required_ to create a Release Issue in [Jira](https://broadworkbench.atlassian.net/browse/CA).
-You should title the issue something like `Bond Release version x.x.x` where `x.x.x` is the semantic version number for 
-the release.  After creating the issue, scroll down to the "Checklist" field and click on the ellipsis `...` icon for 
+You should title the issue something like `Bond Release version x.x.x` (`x.x.x` is a placeholder that will get replaced).  After creating the issue, search for a way to add a "Checklist" (which may be a ☑ icon near the top of the ticket) and click on the ellipsis `...` icon for 
 that field and choose `Load templates`, select `Bond Release Checklist`, and click the `Load templates` button.  
 
 When doing a production deployment, each step of the checklist **must** be performed.

--- a/release-checklist.md
+++ b/release-checklist.md
@@ -5,10 +5,15 @@
 >> You should look at the existing tags to ensure that the tag is incremented properly based on the last released version.  Tags should be plain semver numbers like `1.0.0` and should not have any additional prefix like `v1.0.0` or `releases/1.0.0`.  Suffixes are permitted so long as they conform to the [semver spec](https://semver.org/).
 * [] Manually tag the Docker image with the correct semver number on Quay
 >> Pushing the new tag to the git origin repository will _not_ automatically tag the Docker image.  You will need to manually tag the Docker image with the correct semver number.  Go to the [Bond project on Quay.io](https://quay.io/repository/databiosphere/bond?tab=tags) and navigate to the "Tags" menu.  You should see two new images for `latest` and `develop`.  Confirm that the ages of these images correspond to when you merged your changes into the `develop` branch.  On the right of one of these rows, click on the gear icon and select "Add New Tag".  Enter the semver number for your release.
+>> 
+>> NOTE: if you have issues logging in, you may need to link your old Quay account with new redhat account at https://recovery.quay.io/
+* [] Update the ticket name, replacing `x.x.x` with the semver number.
 * [] Create Bond Release in Jira
 >> In Jira, make sure the Bond Release exists or create a new one in the [Cloud Integration Project](https://broadworkbench.atlassian.net/projects/CA?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page) named like: `Bond-X.Y.Z` where `X.Y.Z` is the same semantic version number you created in the previous step
 * [] Set the `Fix Version` for each Jira Issue included in this release
->> Set the `Fix Version` field to the release name you created in the previous step.  The status of each of these issues should be: `Merged to Dev`.  If the status is something else, then either the issue should not be included in the release, the release is not ready, or the issue has already been released. Each Jira issue must have a clear description of the change and its security impact.
+>> Find the tickets included in this release by looking through the commits/PRs committed to the main branch since the last release.
+>> 
+>> Set the `Fix Version` field to the release name you created in the previous step.  The status of each of these issues should be: `Merged to Dev`.  If the status is something else, verify whether the ticket should be included in this release. Each Jira issue must have a clear description of the change and its security impact.
 * [] Set the `Fix Version` on _this_ Release Issue 
 --- Deploy and Test
 * [] Deploy to `dev` and perform manual test


### PR DESCRIPTION
\<your comments for this PR go here\>
https://broadworkbench.atlassian.net/browse/ID-45

Updates that I think will help remove some friction for the next time I (and hopefully others) do a release.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
