### PR TITLE
ID-33 Log a stacktrace for Werkzeug exceptions

### DIFF
--- a/bond_app/json_exception_handler.py
+++ b/bond_app/json_exception_handler.py
@@ -1,3 +1,5 @@
+import logging
+
 from flask import jsonify
 from werkzeug import exceptions
 
@@ -28,6 +30,7 @@ class JsonExceptionHandler(object):
         else:
             response = jsonify(error=str(error))
             response.status_code = 500
+        logging.exception(error)
         return response
 
     def init_app(self, app):


### PR DESCRIPTION
Turns out, Bond overrides the default exception handler in Flask, and never actually logged Werkzeug exceptions, only transforming them to JSON and returning them to the browser. This PR simply `logging.exception`s the caught error so that we have a record of the failure before returning the response. 

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
