### PR TITLE
ID-263, ID-263: Enable sts and cache control headers.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,3 @@ If you're making breaking changes to the API, do the following:
 1. Check in with Comms to explain the change and the impact on users.
 2. Write an email to users explaining the change and send it least a few days BEFORE the release goes out. You'll need to explain the change and what users need to do to update their code. Get Comms signoff on the wording.
 3. Get someone Suitable to send the email to api-users@firecloud.org.
-
-## FISMA documentation changes
-
-If you're making changes to authentication, authorization, encryption, or audit trails, you should check in with Bernick or Jyotin to see if our security documentation should be updated.

--- a/automation/tests/api_test.py
+++ b/automation/tests/api_test.py
@@ -16,6 +16,8 @@ class BaseApiTestCase(unittest.TestCase):
         self.assertEqual(response.headers["Content-Type"], "application/json")
         self.assertEqual(response.headers["X-Content-Type-Options"], "nosniff")
         self.assertEqual(response.headers["X-Frame-Options"], "deny")
+        self.assertEqual(response.headers["Strict-Transport-Security"], "max-age=63072000; includeSubDomains; preload")
+        self.assertEqual(response.headers["Cache-Control"], "max-age=0, must-revalidate, no-cache, no-store, private")
 
 
 class PublicApiTestCase(BaseApiTestCase):

--- a/main.py
+++ b/main.py
@@ -93,3 +93,16 @@ def add_nosniff_content_type_header(response):
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "deny"
     return response
+
+@app.after_request
+def add_strict_transport_security_header(response):
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+    # recommended settings by mozilla, max-age is 2 years in seconds
+    response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains; preload"
+    return response
+
+@app.after_request
+def add_cache_control_header(response):
+    # https://grayduck.mn/2021/09/13/cache-control-recommendations/
+    response.headers["Cache-Control"] = "max-age=0, must-revalidate, no-cache, no-store, private"
+    return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ google-cloud-datastore==1.15.3
 Flask==1.1.1
 Werkzeug==0.16.0
 webargs==5.5.3
-grpcio==1.48.1
+grpcio==1.34.0
 protorpc==0.12.0
 gunicorn==20.0.4
 flask-cors==3.0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ google-cloud-datastore==1.15.3
 Flask==1.1.1
 Werkzeug==0.16.0
 webargs==5.5.3
-grpcio==1.34.0
+grpcio==1.48.1
 protorpc==0.12.0
 gunicorn==20.0.4
 flask-cors==3.0.10


### PR DESCRIPTION
This pr addresses both https://broadworkbench.atlassian.net/browse/ID-263 and https://broadworkbench.atlassian.net/browse/ID-262

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
