### PR TITLE
ID-261 CSRF Mitigation

### DIFF
--- a/automation/helpers/json_responses.py
+++ b/automation/helpers/json_responses.py
@@ -565,6 +565,71 @@ json_schema_test_exchange_auth_code_without_oauthcode_param = {
   }
 }
 
+json_schema_test_exchange_auth_code_invalid_nonce_param = {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "error"
+  ],
+  "properties": {
+    "error": {
+      "type": "object",
+      "required": [
+        "message",
+        "code",
+        "errors"
+      ],
+      "properties": {
+        "message": {
+          "type": "string",
+          "enum": [
+            "Invalid OAuth2 State: Invalid nonce"
+          ],
+        },
+        "code": {
+          "type": "integer",
+          "default": 0,
+          "enum": [
+            500
+          ]
+        },
+        "errors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "reason",
+              "domain",
+              "message"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "internalServerError"
+                ],
+              },
+              "domain": {
+                "type": "string",
+                "enum": [
+                  "global"
+                ],
+              },
+              "message": {
+                "type": "string",
+                "enum": [
+                  "Invalid OAuth2 State: Invalid nonce"
+                ],
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+
 """Json Schemas for LinkedUserTestCase tests"""
 json_schema_test_get_link_status = json_schema_test_exchange_auth_code
 json_schema_test_get_access_token = {

--- a/automation/tests/api_test.py
+++ b/automation/tests/api_test.py
@@ -106,6 +106,9 @@ class AuthorizedBaseCase(BaseApiTestCase):
 class AuthorizedUnlinkedUser(AuthorizedBaseCase):
     """Base class for setting up test cases that need the user to be logged in but not linked in Bond"""
 
+    # {"foo":"bar"}
+    foo_bar_state = "eyJmb28iOiJiYXIifQ%3D%3D"
+
     def setUp(self):
         self.token = self.user_credentials[self.hermione_email].get_access_token()
         self.unlink(self.token)
@@ -122,7 +125,7 @@ class AuthorizationUrlApiTestCase(AuthorizedUnlinkedUser):
     """Tests Bond's authorization-url endpoints that now require a bearer token"""
 
     def test_get_auth_url(self):
-        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/authorization-url" + "?scopes=openid&scopes=google_credentials&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback&state=eyJmb28iOiJiYXIifQ%3D%3D"
+        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/authorization-url" + "?scopes=openid&scopes=google_credentials&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback&state=" + self.foo_bar_state
         r = requests.get(url, headers=self.bearer_token_header(self.token))
         self.assertEqual(200, r.status_code)
         response_json_dict = json.loads(r.text)
@@ -201,7 +204,7 @@ class ExchangeAuthCodeNegativeTestCase(AuthorizedUnlinkedUser):
     oauthcode, it only checks that it is present.
     """
     def test_exchange_auth_code_without_authz_header(self):
-        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?oauthcode=IgnoredByMockProvider&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback&state=eyJmb28iOiJiYXIifQ%3D%3D"
+        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?oauthcode=IgnoredByMockProvider&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback&state=" + self.foo_bar_state
         r = requests.post(url)
         self.assertEqual(401, r.status_code)
         response_json_dict = json.loads(r.text)
@@ -209,7 +212,7 @@ class ExchangeAuthCodeNegativeTestCase(AuthorizedUnlinkedUser):
         self.assertCorrectResponseHeaders(r)
 
     def test_exchange_auth_code_without_redirect_uri_param(self):
-        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?oauthcode=IgnoredByMockProvider&state=eyJmb28iOiJiYXIifQ%3D%3D"
+        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?oauthcode=IgnoredByMockProvider&state=" + self.foo_bar_state
         r = requests.post(url, headers=self.bearer_token_header(self.token))
         self.assertEqual(400, r.status_code)
         response_json_dict = json.loads(r.text)
@@ -217,7 +220,7 @@ class ExchangeAuthCodeNegativeTestCase(AuthorizedUnlinkedUser):
         self.assertCorrectResponseHeaders(r)
 
     def test_exchange_auth_code_without_oauthcode_param(self):
-        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback&state=eyJmb28iOiJiYXIifQ%3D%3D"
+        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback&state=" + self.foo_bar_state
         r = requests.post(url, headers=self.bearer_token_header(self.token))
         self.assertEqual(400, r.status_code)
         response_json_dict = json.loads(r.text)

--- a/automation/tests/api_test.py
+++ b/automation/tests/api_test.py
@@ -1,10 +1,14 @@
+import base64
 import json
 import unittest
+import urllib.parse
+
 import requests
 import os
 from automation.helpers.user_credentials import UserCredentials
 from jsonschema import validate
 from automation.helpers.json_responses import *
+
 
 class BaseApiTestCase(unittest.TestCase):
     env = os.getenv("ENV", "dev")
@@ -35,30 +39,6 @@ class PublicApiTestCase(BaseApiTestCase):
         self.assertEqual(200, r.status_code)
         response_json_dict = json.loads(r.text)
         validate(instance=response_json_dict, schema=json_schema_test_list_providers)
-        self.assertCorrectResponseHeaders(r)
-
-    def test_get_auth_url(self):
-        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/authorization-url" + "?scopes=openid&scopes=google_credentials&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback&state=eyJmb28iPSJiYXIifQ=="
-        r = requests.get(url)
-        self.assertEqual(200, r.status_code)
-        response_json_dict = json.loads(r.text)
-        validate(instance=response_json_dict, schema=json_schema_test_get_auth_url)
-        self.assertCorrectResponseHeaders(r)
-
-    def test_get_auth_url_without_params(self):
-        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/authorization-url"
-        r = requests.get(url)
-        self.assertEqual(400, r.status_code)
-        response_json_dict = json.loads(r.text)
-        validate(instance=response_json_dict, schema=json_schema_test_get_auth_url_without_params)
-        self.assertCorrectResponseHeaders(r)
-
-    def test_get_auth_url_with_only_redirect_param(self):
-        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/authorization-url" + "?redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback"
-        r = requests.get(url)
-        self.assertEqual(200, r.status_code)
-        response_json_dict = json.loads(r.text)
-        validate(instance=response_json_dict, schema=json_schema_test_get_auth_url_with_only_redirect_param)
         self.assertCorrectResponseHeaders(r)
 
     def test_get_swagger_ui(self):
@@ -130,6 +110,41 @@ class AuthorizedUnlinkedUser(AuthorizedBaseCase):
         self.token = self.user_credentials[self.hermione_email].get_access_token()
         self.unlink(self.token)
 
+    def get_state_with_nonce(self):
+        authz_url = self.bond_base_url + "/api/link/v1/" + self.provider + "/authorization-url?scopes=openid&scopes=google_credentials&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback"
+        authz_url_response = requests.get(authz_url, headers=self.bearer_token_header(self.token))
+        authz_url_with_state = json.loads(authz_url_response.text)['url']
+        query_params_dict = urllib.parse.parse_qs(urllib.parse.urlparse(authz_url_with_state).query)
+        return query_params_dict['state'][0]
+
+
+class AuthorizationUrlApiTestCase(AuthorizedUnlinkedUser):
+    """Tests Bond's authorization-url endpoints that now require a bearer token"""
+
+    def test_get_auth_url(self):
+        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/authorization-url" + "?scopes=openid&scopes=google_credentials&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback&state=eyJmb28iOiJiYXIifQ%3D%3D"
+        r = requests.get(url, headers=self.bearer_token_header(self.token))
+        self.assertEqual(200, r.status_code)
+        response_json_dict = json.loads(r.text)
+        validate(instance=response_json_dict, schema=json_schema_test_get_auth_url)
+        self.assertCorrectResponseHeaders(r)
+
+    def test_get_auth_url_without_params(self):
+        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/authorization-url"
+        r = requests.get(url, headers=self.bearer_token_header(self.token))
+        self.assertEqual(400, r.status_code)
+        response_json_dict = json.loads(r.text)
+        validate(instance=response_json_dict, schema=json_schema_test_get_auth_url_without_params)
+        self.assertCorrectResponseHeaders(r)
+
+    def test_get_auth_url_with_only_redirect_param(self):
+        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/authorization-url" + "?redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback"
+        r = requests.get(url, headers=self.bearer_token_header(self.token))
+        self.assertEqual(200, r.status_code)
+        response_json_dict = json.loads(r.text)
+        validate(instance=response_json_dict, schema=json_schema_test_get_auth_url_with_only_redirect_param)
+        self.assertCorrectResponseHeaders(r)
+
 
 class UnlinkedUserTestCase(AuthorizedUnlinkedUser):
     """Tests APIs that require a bearer token, but the users' accounts are NOT linked in Bond"""
@@ -168,7 +183,8 @@ class ExchangeAuthCodeTestCase(AuthorizedUnlinkedUser):
     """Tests the Exchange Auth Code API"""
 
     def test_exchange_auth_code(self):
-        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?oauthcode=IgnoredByMockProvider&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback"
+        state = self.get_state_with_nonce()
+        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?oauthcode=IgnoredByMockProvider&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback&state=" + state
         r = requests.post(url, headers=self.bearer_token_header(self.token))
         self.assertEqual(200, r.status_code, "Response code was not 200.  Response Body: %s" % r.text)
         response_json_dict = json.loads(r.text)
@@ -185,7 +201,7 @@ class ExchangeAuthCodeNegativeTestCase(AuthorizedUnlinkedUser):
     oauthcode, it only checks that it is present.
     """
     def test_exchange_auth_code_without_authz_header(self):
-        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?oauthcode=IgnoredByMockProvider&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback"
+        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?oauthcode=IgnoredByMockProvider&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback&state=eyJmb28iOiJiYXIifQ%3D%3D"
         r = requests.post(url)
         self.assertEqual(401, r.status_code)
         response_json_dict = json.loads(r.text)
@@ -193,7 +209,7 @@ class ExchangeAuthCodeNegativeTestCase(AuthorizedUnlinkedUser):
         self.assertCorrectResponseHeaders(r)
 
     def test_exchange_auth_code_without_redirect_uri_param(self):
-        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?oauthcode=IgnoredByMockProvider"
+        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?oauthcode=IgnoredByMockProvider&state=eyJmb28iOiJiYXIifQ%3D%3D"
         r = requests.post(url, headers=self.bearer_token_header(self.token))
         self.assertEqual(400, r.status_code)
         response_json_dict = json.loads(r.text)
@@ -201,11 +217,31 @@ class ExchangeAuthCodeNegativeTestCase(AuthorizedUnlinkedUser):
         self.assertCorrectResponseHeaders(r)
 
     def test_exchange_auth_code_without_oauthcode_param(self):
-        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback"
+        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback&state=eyJmb28iOiJiYXIifQ%3D%3D"
         r = requests.post(url, headers=self.bearer_token_header(self.token))
         self.assertEqual(400, r.status_code)
         response_json_dict = json.loads(r.text)
         validate(instance=response_json_dict, schema=json_schema_test_exchange_auth_code_without_oauthcode_param)
+        self.assertCorrectResponseHeaders(r)
+
+    def test_exchange_auth_code_without_state_param(self):
+        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?oauthcode=IgnoredByMockProvider&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback"
+        r = requests.post(url, headers=self.bearer_token_header(self.token))
+        self.assertEqual(400, r.status_code)
+        response_json_dict = json.loads(r.text)
+        validate(instance=response_json_dict, schema=json_schema_test_exchange_auth_code_without_oauthcode_param)
+        self.assertCorrectResponseHeaders(r)
+
+    def test_exchange_auth_code_with_wrong_state_param(self):
+        self.get_state_with_nonce()
+        different_state = json.dumps({'nonce': 'different_nonce_than_saved'}).encode('utf-8')
+        b64_different_state = base64.b64encode(different_state)
+        url_encoded_different_state = urllib.parse.quote(b64_different_state)
+        url = self.bond_base_url + "/api/link/v1/" + self.provider + "/oauthcode?oauthcode=IgnoredByMockProvider&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback&state=" + url_encoded_different_state
+        r = requests.post(url, headers=self.bearer_token_header(self.token))
+        self.assertEqual(500, r.status_code)
+        response_json_dict = json.loads(r.text)
+        validate(instance=response_json_dict, schema=json_schema_test_exchange_auth_code_invalid_nonce_param)
         self.assertCorrectResponseHeaders(r)
 
 

--- a/bond_app/bond.py
+++ b/bond_app/bond.py
@@ -64,10 +64,11 @@ class Bond:
         :param provider: OAuth provider
         :return: Two values: datetime when token was issued, username for whom the token was issued
         """
-        decoded_state = json.loads(base64.b64decode(b64_state))
-        if 'nonce' not in decoded_state:
+        decoded_state = base64.b64decode(b64_state)
+        state = json.loads(decoded_state)
+        if 'nonce' not in state:
             raise exceptions.InternalServerError("Invalid OAuth2 State: No nonce provided")
-        state_valid = self.oauth2_state_store.validate_and_delete(sam_user_id, provider, decoded_state['nonce'])
+        state_valid = self.oauth2_state_store.validate_and_delete(sam_user_id, provider, state['nonce'])
         if not state_valid:
             raise exceptions.InternalServerError("Invalid OAuth2 State: Invalid nonce")
         token_response = self.oauth_adapter.exchange_authz_code(authz_code, redirect_uri)

--- a/bond_app/bond.py
+++ b/bond_app/bond.py
@@ -1,3 +1,5 @@
+import base64
+import json
 from datetime import datetime
 import logging
 from .jwt_token import JwtToken
@@ -5,12 +7,16 @@ from .jwt_token import JwtToken
 from werkzeug import exceptions
 from dataclasses import dataclass
 
+from .oauth2_state_store import OAuth2StateStore
+
+
 class Bond:
     def __init__(self,
                  oauth_adapter,
                  fence_api,
                  cache_api,
                  refresh_token_store,
+                 oauth2_state_store,
                  fence_tvm,
                  provider_name,
                  user_name_path_expr,
@@ -20,25 +26,33 @@ class Bond:
         self.fence_api = fence_api
         self.cache_api = cache_api
         self.refresh_token_store = refresh_token_store
+        self.oauth2_state_store = oauth2_state_store
         self.fence_tvm = fence_tvm
         self.provider_name = provider_name
         self.user_name_path_expr = user_name_path_expr
         self.extra_authz_url_params = extra_authz_url_params
 
-    def build_authz_url(self, scopes, redirect_uri, state=None):
+    def build_authz_url(self, scopes, redirect_uri, sam_user_id, provider, state=None):
         """
         Builds an OAuth authorization URL that a user must use to initiate the OAuth dance.  Will automatically append
         all `self.extra_authz_url_params` to the resulting url.
         :param scopes: Array of scopes (0 to many) that the client requires
         :param redirect_uri: A URL encoded string representing the URI that the Authorizing Service will redirect the
         user to after the user successfully authorizes this client
+        :param sam_user_id: The Sam user of this request
+        :param provider: The OAuth Provider of this request
         :param state: A URL encoded Base64 string representing a JSON object of state information that the requester requires
         back with the redirect
         :return: A plain (not URL encoded) String
         """
-        return self.oauth_adapter.build_authz_url(scopes, redirect_uri, state, self.extra_authz_url_params)
+        encoded_state_with_nonce, nonce = self.oauth2_state_store.state_with_nonce(state)
+        authz_url = self.oauth_adapter.build_authz_url(scopes, redirect_uri, encoded_state_with_nonce,
+                                                       self.extra_authz_url_params)
+        # save nonce after creating authz_url so that we don't save states of invalid requests
+        self.oauth2_state_store.save(sam_user_id, provider, nonce)
+        return authz_url
 
-    def exchange_authz_code(self, authz_code, redirect_uri, sam_user_id):
+    def exchange_authz_code(self, authz_code, redirect_uri, sam_user_id, b64_state, provider):
         """
         Given an authz_code and user information, exchange that code for an OAuth Access Token and Refresh Token.  Store
         the refresh token for later, and return the datetime the token was issued along with the username for whom it
@@ -46,8 +60,14 @@ class Bond:
         :param authz_code: Authorization code from OAuth provider
         :param redirect_uri: redirect url that was used when generating the code - will use default if None
         :param sam_user_id: Id stored in Sam for user who initiated request
+        :param b64_state: Base64-encoded state with OAuth2State nonce
+        :param provider: OAuth provider
         :return: Two values: datetime when token was issued, username for whom the token was issued
         """
+        decoded_state = json.loads(base64.b64decode(b64_state))
+        state_valid = self.oauth2_state_store.validate_and_delete(sam_user_id, provider, decoded_state['nonce'])
+        if not state_valid:
+            raise exceptions.InternalServerError("Invalid OAuth2 State")
         token_response = self.oauth_adapter.exchange_authz_code(authz_code, redirect_uri)
         jwt_token = JwtToken(token_response.get(FenceKeys.ID_TOKEN), self.user_name_path_expr)
         if FenceKeys.REFRESH_TOKEN not in token_response:

--- a/bond_app/bond.py
+++ b/bond_app/bond.py
@@ -65,9 +65,11 @@ class Bond:
         :return: Two values: datetime when token was issued, username for whom the token was issued
         """
         decoded_state = json.loads(base64.b64decode(b64_state))
+        if 'nonce' not in decoded_state:
+            raise exceptions.InternalServerError("Invalid OAuth2 State: No nonce provided")
         state_valid = self.oauth2_state_store.validate_and_delete(sam_user_id, provider, decoded_state['nonce'])
         if not state_valid:
-            raise exceptions.InternalServerError("Invalid OAuth2 State")
+            raise exceptions.InternalServerError("Invalid OAuth2 State: Invalid nonce")
         token_response = self.oauth_adapter.exchange_authz_code(authz_code, redirect_uri)
         jwt_token = JwtToken(token_response.get(FenceKeys.ID_TOKEN), self.user_name_path_expr)
         if FenceKeys.REFRESH_TOKEN not in token_response:

--- a/bond_app/fence_token_storage.py
+++ b/bond_app/fence_token_storage.py
@@ -1,7 +1,8 @@
-from collections import namedtuple
 import datetime
 import time
 import logging
+from dataclasses import dataclass
+
 from google.cloud import ndb
 
 logger = logging.getLogger(__name__)
@@ -9,8 +10,12 @@ logger = logging.getLogger(__name__)
 # How long to keep a fence service account key before expiring it.
 _FSA_KEY_LIFETIME = datetime.timedelta(days=5)
 
+
 # A tuple of a provider_name and user_id to use as a unique key for a user/provider combination.
-ProviderUser = namedtuple("ProviderUser", ["provider_name", "user_id"])
+@dataclass(unsafe_hash=True)
+class ProviderUser:
+    provider_name: str
+    user_id: str
 
 
 class FenceServiceAccount(ndb.Model):

--- a/bond_app/oauth2_state_store.py
+++ b/bond_app/oauth2_state_store.py
@@ -36,13 +36,15 @@ class OAuth2StateStore:
         ouath2_nonce = OAuth2State(key=OAuth2StateStore._oauth2_state_store_key(user_id, provider), nonce=nonce)
         ouath2_nonce.put()
 
-    def delete_if_exists(self, user_id, provider_name) -> bool:
+    def validate_and_delete(self, user_id, provider_name, nonce) -> bool:
         key = OAuth2StateStore._oauth2_state_store_key(user_id, provider_name)
-        if key.get():
+        oauth2_state = key.get()
+        is_valid = False
+        if oauth2_state:
+            if oauth2_state.nonce == nonce:
+                is_valid = True
             key.delete()
-            return True
-        else:
-            return False
+        return is_valid
 
     # def build_oauth2_state(self, user_id, provider_name):
 

--- a/bond_app/oauth2_state_store.py
+++ b/bond_app/oauth2_state_store.py
@@ -34,8 +34,8 @@ class OAuth2StateStore:
         :param provider:
         :param nonce: random value for csrf protection
         """
-        ouath2_nonce = OAuth2State(key=OAuth2StateStore._oauth2_state_store_key(user_id, provider), nonce=nonce)
-        ouath2_nonce.put()
+        oauth2_nonce = OAuth2State(key=OAuth2StateStore._oauth2_state_store_key(user_id, provider), nonce=nonce)
+        oauth2_nonce.put()
 
     def validate_and_delete(self, user_id, provider_name, nonce) -> bool:
         key = OAuth2StateStore._oauth2_state_store_key(user_id, provider_name)

--- a/bond_app/oauth2_state_store.py
+++ b/bond_app/oauth2_state_store.py
@@ -54,7 +54,9 @@ class OAuth2StateStore:
             decoded_state = json.loads(decoded_raw)
         nonce = secrets.token_urlsafe()
         decoded_state_with_nonce = {**decoded_state, 'nonce': nonce}
-        return base64.b64encode(json.dumps(decoded_state_with_nonce).encode('utf-8')), nonce
+        dumped_state = json.dumps(decoded_state_with_nonce)
+        utf8_dumped_state = dumped_state.encode('utf-8')
+        return base64.b64encode(utf8_dumped_state), nonce
 
     @staticmethod
     def _oauth2_state_store_key(user_id, provider_name):

--- a/bond_app/oauth2_state_store.py
+++ b/bond_app/oauth2_state_store.py
@@ -50,7 +50,8 @@ class OAuth2StateStore:
         if not state:
             decoded_state = {}
         else:
-            decoded_state = json.loads(base64.b64decode(state))
+            decoded_raw = base64.b64decode(state)
+            decoded_state = json.loads(decoded_raw)
         nonce = secrets.token_urlsafe()
         decoded_state_with_nonce = {**decoded_state, 'nonce': nonce}
         return base64.b64encode(json.dumps(decoded_state_with_nonce).encode('utf-8')), nonce

--- a/bond_app/oauth2_state_store.py
+++ b/bond_app/oauth2_state_store.py
@@ -40,12 +40,11 @@ class OAuth2StateStore:
     def validate_and_delete(self, user_id, provider_name, nonce) -> bool:
         key = OAuth2StateStore._oauth2_state_store_key(user_id, provider_name)
         oauth2_state = key.get()
-        is_valid = False
-        if oauth2_state:
-            if oauth2_state.nonce == nonce:
-                is_valid = True
+        if oauth2_state is None:
+            return False
+        else:
             key.delete()
-        return is_valid
+            return oauth2_state.nonce == nonce
 
     def state_with_nonce(self, state):
         if not state:

--- a/bond_app/oauth2_state_store.py
+++ b/bond_app/oauth2_state_store.py
@@ -1,0 +1,55 @@
+import secrets
+from collections import namedtuple
+from google.cloud import ndb
+
+# Information associated with a tokens for refreshing service account credentials.
+OAuth2StateInfo = namedtuple('OAuth2StateInfo', ['nonce'])
+
+
+class OAuth2State(ndb.Model):
+    """
+    Model used to store entries in Datastore.
+
+    This is not used as the return type for OAuth2StateStore because it depends on ndb, which we want to stub out for unit
+    tests.
+    """
+    nonce = ndb.StringProperty()
+
+    @classmethod
+    def kind_name(cls):
+        return cls.__name__
+
+
+class OAuth2StateStore:
+    """
+    Stores OAuth2 State nonces for csrf protection.
+    """
+
+
+    def save(self, user_id, provider, nonce):
+        """
+        Persists a RefreshToken by creating a new entity or updating an existing entity with the same id
+        :param user_id
+        :param provider:
+        :param nonce: random value for csrf protection
+        """
+        ouath2_nonce = OAuth2State(key=OAuth2StateStore._oauth2_state_store_key(user_id, provider), nonce=nonce)
+        ouath2_nonce.put()
+
+    def delete_if_exists(self, user_id, provider_name) -> bool:
+        key = OAuth2StateStore._oauth2_state_store_key(user_id, provider_name)
+        if key.get():
+            key.delete()
+            return True
+        else:
+            return False
+
+    # def build_oauth2_state(self, user_id, provider_name):
+
+    @staticmethod
+    def _oauth2_state_store_key(user_id, provider_name):
+        return ndb.Key("OAuth2State", user_id, OAuth2State, provider_name)
+
+    @staticmethod
+    def random_nonce():
+        return secrets.token_urlsafe()

--- a/bond_app/oauth2_state_store.py
+++ b/bond_app/oauth2_state_store.py
@@ -32,7 +32,7 @@ class OAuth2StateStore:
 
     def save(self, user_id, provider, nonce):
         """
-        Persists a RefreshToken by creating a new entity or updating an existing entity with the same id
+        Persists a OAuth2State by creating a new entity or updating an existing entity with the same id
         :param user_id
         :param provider:
         :param nonce: random value for csrf protection

--- a/bond_app/oauth2_state_store.py
+++ b/bond_app/oauth2_state_store.py
@@ -1,11 +1,14 @@
 import base64
 import json
 import secrets
-from collections import namedtuple
 from google.cloud import ndb
+from dataclasses import dataclass
+
 
 # Information associated with a tokens for refreshing service account credentials.
-OAuth2StateInfo = namedtuple('OAuth2StateInfo', ['nonce'])
+@dataclass
+class OAuth2StateInfo:
+    nonce: str
 
 
 class OAuth2State(ndb.Model):

--- a/bond_app/oauth2_state_store.py
+++ b/bond_app/oauth2_state_store.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import secrets
 from collections import namedtuple
 from google.cloud import ndb
@@ -25,7 +27,6 @@ class OAuth2StateStore:
     Stores OAuth2 State nonces for csrf protection.
     """
 
-
     def save(self, user_id, provider, nonce):
         """
         Persists a RefreshToken by creating a new entity or updating an existing entity with the same id
@@ -46,12 +47,17 @@ class OAuth2StateStore:
             key.delete()
         return is_valid
 
-    # def build_oauth2_state(self, user_id, provider_name):
+    def state_with_nonce(self, state):
+        if not state:
+            decoded_state = {}
+        else:
+            decoded_state = json.loads(base64.b64decode(state))
+        nonce = secrets.token_urlsafe()
+        decoded_state_with_nonce = {**decoded_state, 'nonce': nonce}
+        return base64.b64encode(json.dumps(decoded_state_with_nonce).encode('utf-8')), nonce
 
     @staticmethod
     def _oauth2_state_store_key(user_id, provider_name):
         return ndb.Key("OAuth2State", user_id, OAuth2State, provider_name)
 
-    @staticmethod
-    def random_nonce():
-        return secrets.token_urlsafe()
+

--- a/bond_app/token_store.py
+++ b/bond_app/token_store.py
@@ -1,8 +1,16 @@
-from collections import namedtuple
+from dataclasses import dataclass
+from datetime import datetime
+
 from google.cloud import ndb
 
+
 # Information associated with a tokens for refreshing service account credentials.
-RefreshTokenInfo = namedtuple('RefreshTokenInfo', ['token', 'issued_at', 'username'])
+@dataclass
+class RefreshTokenInfo:
+    token: str
+    issued_at: datetime
+    username: str
+
 
 class RefreshToken(ndb.Model):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,13 +9,13 @@ google-auth==1.24.0
 google-cloud-core==1.5.0
 google-cloud-logging==2.0.2
 google-api-core[grpc]==1.24.1
-googleapis-common-protos==1.52.0
+googleapis-common-protos==1.56.2
 google-cloud-ndb==1.7.2
 google-cloud-datastore==1.15.3
 Flask==1.1.1
 Werkzeug==0.16.0
 webargs==5.5.3
-grpcio==1.34.0
+grpcio==1.48.1
 protorpc==0.12.0
 gunicorn==20.0.4
 flask-cors==3.0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ google-auth==1.24.0
 google-cloud-core==1.5.0
 google-cloud-logging==2.0.2
 google-api-core[grpc]==1.24.1
-googleapis-common-protos==1.56.2
+googleapis-common-protos==1.52.0
 google-cloud-ndb==1.7.2
 google-cloud-datastore==1.15.3
 Flask==1.1.1

--- a/swagger/api-docs.yaml
+++ b/swagger/api-docs.yaml
@@ -132,6 +132,12 @@ paths:
           schema:
             type: string
             example: http://local.broadinstitute.org/#fence-callback
+        - name: state
+          in: query
+          required: true
+          description: A URL encoded Base64 string representing a JSON object of state containing the nonce, as returned by the call to authorization-url.
+          schema:
+            type: string
       responses:
         '200':
           $ref: '#/components/responses/LinkInfoResponse'

--- a/swagger/api-docs.yaml
+++ b/swagger/api-docs.yaml
@@ -74,7 +74,6 @@ paths:
       summary: Builds an OAuth authorization URL that a user must use to initiate the OAuth dance.
       tags: [ bond ]
       operationId: getProviderAuthUrl
-      security: [ ]
       parameters:
         - $ref: '#/components/parameters/providerParam'
         - name: redirect_uri

--- a/swagger/api-docs.yaml
+++ b/swagger/api-docs.yaml
@@ -71,7 +71,7 @@ paths:
 
   /api/link/v1/{provider}/authorization-url:
     get:
-      summary: Builds an OAuth authorization URL that a user must use to initiate the OAuth dance.
+      summary: Builds an OAuth authorization URL that a user must use to initiate the OAuth dance. Creates a 1 time use link. There can only be 1 active link per user per provider. The last link created will invalidate any prior links.
       tags: [ bond ]
       operationId: getProviderAuthUrl
       parameters:

--- a/tests/datastore_emulator/oauth2_state_store_test.py
+++ b/tests/datastore_emulator/oauth2_state_store_test.py
@@ -1,0 +1,47 @@
+import base64
+import json
+import unittest
+
+from bond_app.oauth2_state_store import OAuth2StateStore
+from tests.datastore_emulator import datastore_emulator_utils
+
+provider_name = "test"
+
+
+class OAuth2StateStoreTestCase(unittest.TestCase):
+
+    def setUp(self):
+        # Make sure to run these tests with a Datastore Emulator running or else they will fail with 'InternalError.'
+        # See the README in this directory.
+        datastore_emulator_utils.setUp(self)
+
+        self.user_id = "abc123"
+        self.state = base64.b64encode(json.dumps({}).encode('utf-8'))
+        self.key = OAuth2StateStore._oauth2_state_store_key(self.user_id, provider_name)
+
+    def test_save(self):
+        oauth2_state_store = OAuth2StateStore()
+        state, nonce = oauth2_state_store.state_with_nonce(self.state)
+        self.assertIsNone(self.key.get())
+        oauth2_state_store.save(self.user_id, provider_name, nonce)
+        saved_state = self.key.get()
+        self.assertIsNotNone(saved_state)
+        self.assertEqual(nonce, saved_state.nonce)
+
+    def test_validate_and_delete_success(self):
+        oauth2_state_store = OAuth2StateStore()
+        state, nonce = oauth2_state_store.state_with_nonce(self.state)
+        oauth2_state_store.save(self.user_id, provider_name, nonce)
+        is_valid = oauth2_state_store.validate_and_delete(self.user_id, provider_name, nonce)
+        self.assertTrue(is_valid)
+        self.assertIsNone(self.key.get())
+
+    def test_validate_and_delete_failure(self):
+        oauth2_state_store = OAuth2StateStore()
+        state, nonce = oauth2_state_store.state_with_nonce(self.state)
+        state2, nonce2 = oauth2_state_store.state_with_nonce(self.state)
+        oauth2_state_store.save(self.user_id, provider_name, nonce)
+        is_valid = oauth2_state_store.validate_and_delete(self.user_id, provider_name, nonce2)
+        self.assertFalse(is_valid)
+        # Even if the state is invalid, the key should still get deleted
+        self.assertIsNone(self.key.get())

--- a/tests/datastore_emulator/oauth2_state_store_test.py
+++ b/tests/datastore_emulator/oauth2_state_store_test.py
@@ -16,7 +16,9 @@ class OAuth2StateStoreTestCase(unittest.TestCase):
         datastore_emulator_utils.setUp(self)
 
         self.user_id = "abc123"
-        self.state = base64.b64encode(json.dumps({}).encode('utf-8'))
+        empty_state = json.dumps({})
+        utf8_state = empty_state.encode('utf-8')
+        self.state = base64.b64encode(utf8_state)
         self.key = OAuth2StateStore._oauth2_state_store_key(self.user_id, provider_name)
 
     def test_save(self):

--- a/tests/unit/bond_test.py
+++ b/tests/unit/bond_test.py
@@ -27,18 +27,6 @@ def encoded_state():
     return base64.b64encode(utf8_state)
 
 
-def get_url_state(url):
-    parsed_url = urlparse(url)
-    return parse_qs(parsed_url.query)['state'][0]
-
-
-def parse_nonce_from_url_state(url):
-    url_state = get_url_state(url)
-    decoded_state = base64.b64decode(url_state)
-    state_dict = json.loads(decoded_state)
-    return state_dict['nonce']
-
-
 class BondTestCase(unittest.TestCase):
 
     def encoded_state_with_nonce(self):

--- a/tests/unit/bond_test.py
+++ b/tests/unit/bond_test.py
@@ -23,7 +23,9 @@ provider_name = "test"
 
 
 def encoded_state():
-    return base64.b64encode(json.dumps({'foo': 'bar'}).encode('utf-8'))
+    dumped_state = json.dumps({'foo': 'bar'})
+    utf8_state = dumped_state.encode('utf-8')
+    return base64.b64encode(utf8_state)
 
 
 def get_url_state(url):
@@ -32,7 +34,10 @@ def get_url_state(url):
 
 
 def parse_nonce_from_url_state(url):
-    return json.loads(base64.b64decode(get_url_state(url)))['nonce']
+    url_state = get_url_state(url)
+    decoded_state = base64.b64decode(url_state)
+    state_dict = json.loads(decoded_state)
+    return state_dict['nonce']
 
 
 class BondTestCase(unittest.TestCase):
@@ -434,7 +439,9 @@ class BondTestCase(unittest.TestCase):
         state = encoded_state()
 
         self.bond.build_authz_url(scopes, redirect_uri, self.user_id, provider_name, state)
-        state_with_bad_nonce = base64.b64encode(json.dumps({'nonce': 'unsaved_nonce'}).encode('utf-8'))
+        dumped_state = json.dumps({'nonce': 'unsaved_nonce'})
+        utf8_state = dumped_state.encode('utf-8')
+        state_with_bad_nonce = base64.b64encode(utf8_state)
 
         with self.assertRaisesRegex(exceptions.InternalServerError, "Invalid OAuth2 State: Invalid nonce"):
             self.bond.exchange_authz_code("irrelevantString", "redirect", self.user_id, state_with_bad_nonce,

--- a/tests/unit/bond_test.py
+++ b/tests/unit/bond_test.py
@@ -9,7 +9,6 @@ from urllib.parse import urlparse, parse_qs
 from mock import MagicMock
 from werkzeug import exceptions
 
-from bond_app.authentication import UserInfo
 from bond_app.bond import Bond, FenceKeys
 from bond_app.fence_api import FenceApi
 from bond_app.fence_token_vending import FenceTokenVendingMachine

--- a/tests/unit/fake_fence_token_storage.py
+++ b/tests/unit/fake_fence_token_storage.py
@@ -1,9 +1,15 @@
-from collections import namedtuple
 import datetime
+from dataclasses import dataclass
+
 from bond_app.fence_token_storage import _FSA_KEY_LIFETIME
 
+
 # Internal representation of information being stored about a FenceServiceAccount.
-_FenceServiceAccountInfo = namedtuple("_FenceServiceAccountInfo", ["key_json", "expires_at", "update_lock_timeout"])
+@dataclass(unsafe_hash=True)
+class _FenceServiceAccountInfo:
+    key_json: bytes
+    expires_at: datetime
+    update_lock_timeout: datetime
 
 
 class FakeFenceTokenStorage:
@@ -29,8 +35,8 @@ class FakeFenceTokenStorage:
         else:
             key_json = fence_fetch_fn(prep_key_fn(provider_user))
             account_info = _FenceServiceAccountInfo(key_json=key_json,
-                                                   expires_at=datetime.datetime.now() + _FSA_KEY_LIFETIME,
-                                                   update_lock_timeout=None)
+                                                    expires_at=datetime.datetime.now() + _FSA_KEY_LIFETIME,
+                                                    update_lock_timeout=None)
             self.accounts[provider_user] = account_info
 
-        return (account_info.key_json, account_info.expires_at)
+        return account_info.key_json, account_info.expires_at

--- a/tests/unit/fake_oauth2_state_store.py
+++ b/tests/unit/fake_oauth2_state_store.py
@@ -1,38 +1,34 @@
 from collections import namedtuple
-from bond_app.token_store import RefreshTokenInfo
+from bond_app.oauth2_state_store import OAuth2StateInfo
 
 # Internal key class for a user_id and provider_name.
 _UserKey = namedtuple("_UserKey", ["user_id", "provider_name"])
 
 
-class FakeTokenStore():
+class FakeOAuth2StateStore:
     """A fake in memory implementation of TokenStore for unit tests."""
 
     def __init__(self):
-        # Map from TokenStore keys to RefreshTokens.
-        self.tokens = {}
+        # Map from OAuth2Store keys to OAuth2State.
+        self.oauth2_states = {}
 
-    def save(self, user_id, refresh_token_str, issued_at, username, provider_name):
+    def save(self, user_id, provider_name, nonce):
         """
-        Persists a RefreshToken by creating a new entity or updating an existing entity with the same id
+        Persists an OAuth2State by creating a new entity or updating an existing entity with the same id
         :param provider_name:
         :param user_id: identifier for the Google Datastore entity
-        :param refresh_token_str: a refresh token string
-        :param issued_at: datetime at which the token was issued
-        :param username: username for whom the token was issued
+        :param nonce: random nonce for
         """
         key = _UserKey(user_id, provider_name)
-        refresh_token = RefreshTokenInfo(token=refresh_token_str, issued_at=issued_at, username=username)
-        self.tokens[key] = refresh_token
+        state = OAuth2StateInfo(nonce=nonce)
+        self.oauth2_states[key] = state
 
-    def lookup(self, user_id, provider_name):
-        """
-        Retrieves an entity out of Google Datastore of the "RefreshToken" type with the specified user_id
-        :param provider_name:
-        :param user_id: unique identifier for the RefreshToken entity
-        :return: A RefreshToken entity
-        """
-        return self.tokens.get(_UserKey(user_id, provider_name))
-
-    def delete(self, user_id, provider_name):
-        self.tokens.pop(_UserKey(user_id, provider_name), None)
+    def validate_and_delete(self, user_id, provider_name, nonce) -> bool:
+        key = _UserKey(user_id, provider_name)
+        exists = self.oauth2_states.get(key)
+        is_valid = False
+        if exists:
+            state = self.oauth2_states.pop(key, None)
+            if state.nonce == nonce:
+                is_valid = True
+        return is_valid

--- a/tests/unit/fake_oauth2_state_store.py
+++ b/tests/unit/fake_oauth2_state_store.py
@@ -1,10 +1,14 @@
 import base64
 import json
-from collections import namedtuple
+from dataclasses import dataclass
 from bond_app.oauth2_state_store import OAuth2StateInfo
 
+
 # Internal key class for a user_id and provider_name.
-_UserKey = namedtuple("_UserKey", ["user_id", "provider_name"])
+@dataclass(unsafe_hash=True)
+class _UserKey:
+    user_id: str
+    provider_name: str
 
 
 class FakeOAuth2StateStore:

--- a/tests/unit/fake_oauth2_state_store.py
+++ b/tests/unit/fake_oauth2_state_store.py
@@ -1,3 +1,5 @@
+import base64
+import json
 from collections import namedtuple
 from bond_app.oauth2_state_store import OAuth2StateInfo
 
@@ -7,6 +9,8 @@ _UserKey = namedtuple("_UserKey", ["user_id", "provider_name"])
 
 class FakeOAuth2StateStore:
     """A fake in memory implementation of TokenStore for unit tests."""
+
+    test_nonce = "iamasecretnonce"
 
     def __init__(self):
         # Map from OAuth2Store keys to OAuth2State.
@@ -32,3 +36,13 @@ class FakeOAuth2StateStore:
             if state.nonce == nonce:
                 is_valid = True
         return is_valid
+
+    def state_with_nonce(self, state):
+        if not state:
+            decoded_state = {}
+        else:
+            decoded_state = json.loads(base64.b64decode(state))
+        nonce = self.test_nonce
+        decoded_state_with_nonce = {**decoded_state, 'nonce': nonce}
+        return base64.b64encode(json.dumps(decoded_state_with_nonce).encode('utf-8')), nonce
+

--- a/tests/unit/fake_oauth2_state_store.py
+++ b/tests/unit/fake_oauth2_state_store.py
@@ -39,7 +39,8 @@ class FakeOAuth2StateStore:
         if not state:
             decoded_state = {}
         else:
-            decoded_state = json.loads(base64.b64decode(state))
+            decoded_raw = base64.b64decode(state)
+            decoded_state = json.loads(decoded_raw)
         nonce = self.test_nonce
         decoded_state_with_nonce = {**decoded_state, 'nonce': nonce}
         return base64.b64encode(json.dumps(decoded_state_with_nonce).encode('utf-8')), nonce

--- a/tests/unit/fake_oauth2_state_store.py
+++ b/tests/unit/fake_oauth2_state_store.py
@@ -1,0 +1,38 @@
+from collections import namedtuple
+from bond_app.token_store import RefreshTokenInfo
+
+# Internal key class for a user_id and provider_name.
+_UserKey = namedtuple("_UserKey", ["user_id", "provider_name"])
+
+
+class FakeTokenStore():
+    """A fake in memory implementation of TokenStore for unit tests."""
+
+    def __init__(self):
+        # Map from TokenStore keys to RefreshTokens.
+        self.tokens = {}
+
+    def save(self, user_id, refresh_token_str, issued_at, username, provider_name):
+        """
+        Persists a RefreshToken by creating a new entity or updating an existing entity with the same id
+        :param provider_name:
+        :param user_id: identifier for the Google Datastore entity
+        :param refresh_token_str: a refresh token string
+        :param issued_at: datetime at which the token was issued
+        :param username: username for whom the token was issued
+        """
+        key = _UserKey(user_id, provider_name)
+        refresh_token = RefreshTokenInfo(token=refresh_token_str, issued_at=issued_at, username=username)
+        self.tokens[key] = refresh_token
+
+    def lookup(self, user_id, provider_name):
+        """
+        Retrieves an entity out of Google Datastore of the "RefreshToken" type with the specified user_id
+        :param provider_name:
+        :param user_id: unique identifier for the RefreshToken entity
+        :return: A RefreshToken entity
+        """
+        return self.tokens.get(_UserKey(user_id, provider_name))
+
+    def delete(self, user_id, provider_name):
+        self.tokens.pop(_UserKey(user_id, provider_name), None)

--- a/tests/unit/fake_oauth2_state_store.py
+++ b/tests/unit/fake_oauth2_state_store.py
@@ -29,13 +29,11 @@ class FakeOAuth2StateStore:
 
     def validate_and_delete(self, user_id, provider_name, nonce) -> bool:
         key = _UserKey(user_id, provider_name)
-        exists = self.oauth2_states.get(key)
-        is_valid = False
-        if exists:
-            state = self.oauth2_states.pop(key, None)
-            if state.nonce == nonce:
-                is_valid = True
-        return is_valid
+        if key not in self.oauth2_states:
+            return False
+        else:
+            oauth2_state = self.oauth2_states.pop(key)
+            return oauth2_state.nonce == nonce
 
     def state_with_nonce(self, state):
         if not state:

--- a/tests/unit/fake_oauth2_state_store.py
+++ b/tests/unit/fake_oauth2_state_store.py
@@ -43,5 +43,7 @@ class FakeOAuth2StateStore:
             decoded_state = json.loads(decoded_raw)
         nonce = self.test_nonce
         decoded_state_with_nonce = {**decoded_state, 'nonce': nonce}
-        return base64.b64encode(json.dumps(decoded_state_with_nonce).encode('utf-8')), nonce
+        dumped_state = json.dumps(decoded_state_with_nonce)
+        utf8_state = dumped_state.encode('utf-8')
+        return base64.b64encode(utf8_state), nonce
 

--- a/tests/unit/fake_oauth2_state_store.py
+++ b/tests/unit/fake_oauth2_state_store.py
@@ -39,13 +39,13 @@ class FakeOAuth2StateStore:
             oauth2_state = self.oauth2_states.pop(key)
             return oauth2_state.nonce == nonce
 
-    def state_with_nonce(self, state):
+    def state_with_nonce(self, state, override_nonce=None):
         if not state:
             decoded_state = {}
         else:
             decoded_raw = base64.b64decode(state)
             decoded_state = json.loads(decoded_raw)
-        nonce = self.test_nonce
+        nonce = override_nonce if override_nonce else self.test_nonce
         decoded_state_with_nonce = {**decoded_state, 'nonce': nonce}
         dumped_state = json.dumps(decoded_state_with_nonce)
         utf8_state = dumped_state.encode('utf-8')

--- a/tests/unit/fake_token_store.py
+++ b/tests/unit/fake_token_store.py
@@ -1,8 +1,13 @@
-from collections import namedtuple
+from dataclasses import dataclass
+
 from bond_app.token_store import RefreshTokenInfo
 
+
 # Internal key class for a user_id and provider_name.
-_UserKey = namedtuple("_UserKey", ["user_id", "provider_name"])
+@dataclass(unsafe_hash=True)
+class _UserKey:
+    user_id: str
+    provider_name: str
 
 
 class FakeTokenStore():


### PR DESCRIPTION
Remediates https://broadworkbench.atlassian.net/browse/ID-261

Bond needs to implement CSRF protection. To do this, we will provide a random `nonce` in the `state` parameter of the url returned from the `authorization-url` endpoint in Bond. When a client uses that url and gets back an OAuth code, the client must provide that same `nonce` in the state in order for Bond to successfully respond to the `oauthcode` request. 

This is a breaking change, meaning Terra-UI will need to be updated. This cannot merge until Terra-UI forwards state along to bond as a part of the `oauthcode` call.

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
