### PR TITLE
ID-362 Add sentry on boot if SENTRY_DSN is present.

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import os
 
 import flask
 import google.cloud.logging
+import sentry_sdk
 import yaml
 from flask_cors import CORS
 from google.auth.credentials import AnonymousCredentials
@@ -12,6 +13,13 @@ from google.cloud import ndb
 from bond_app import routes
 from bond_app.json_exception_handler import JsonExceptionHandler
 from bond_app.swagger_ui import swaggerui_blueprint, SWAGGER_URL
+
+
+SENTRY_DSN=os.environ.get("SENTRY_DSN")
+if SENTRY_DSN is not None:
+    sentry_sdk.init(
+        dsn="https://93af8286f1f8425cb305e88102b01b12@o54426.ingest.sentry.io/153297"
+    )
 
 client = None
 if os.environ.get('DATASTORE_EMULATOR_HOST'):

--- a/main.py
+++ b/main.py
@@ -17,9 +17,7 @@ from bond_app.swagger_ui import swaggerui_blueprint, SWAGGER_URL
 
 SENTRY_DSN=os.environ.get("SENTRY_DSN")
 if SENTRY_DSN is not None:
-    sentry_sdk.init(
-        dsn="https://93af8286f1f8425cb305e88102b01b12@o54426.ingest.sentry.io/153297"
-    )
+    sentry_sdk.init(dsn=SENTRY_DSN)
 
 client = None
 if os.environ.get('DATASTORE_EMULATOR_HOST'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jsonschema==3.2.0
-requests==2.20.0
-requests-oauthlib==1.3.0
-requests-toolbelt==0.8.0
+requests==2.28.1
+requests-oauthlib
+requests-toolbelt
 pyjwt==1.6.4
 mock==2.0.0
 dpath==2.0.1
@@ -24,3 +24,4 @@ PyYaml==5.4
 jinja2==3.0.3
 itsdangerous==2.0.1
 protobuf==3.20.1
+sentry-sdk==1.11.1


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-362

What:

Adds sentry sdk and initialization if sentry_dsn environment variable is present. 

No ticket sorry I just did this when i had a spare moment.

Why:

Adding sentry to bond might help debug some issues we have been having with it. Basically couldn't hurt to have it.

How:

Adds sentry sdk to the requirements.txt and initializes the sdk if SENTRY_DSN is present. 

---

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
- [ ] **Release to production** - Releasing to prod is a manual process (see [instructions to release to prod](https://github.com/DataBiosphere/bond/blob/develop/README.md#production-deployment-checklist)). Either do this now or create a ticket and schedule the release.
