### PR TITLE
ID-392 Updating ssh key fingerprint for newly rotated key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "ab:2d:12:de:d1:ac:36:0b:6a:02:92:3f:2c:49:98:c9"
+            - "79:fa:13:cf:57:bf:ee:b2:2f:52:d8:ed:d9:95:f4:75"
       - checkout
       - run:
           when: on_success


### PR DESCRIPTION
What:

Rotating ssh key in response to Circle CI security breach.  Old keys have already been revoked.  New key pair is already added to Circle and Github, this change tells Circle the fingerprint of the key to use when running builds going forward.

https://broadworkbench.atlassian.net/browse/ID-392

Why:

For security bruh.  

How:

Without an SSH key, you can neither check out code nor tag it after building, which is part of our defined build process.
=

---

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
- [ ] **Release to production** - Releasing to prod is a manual process (see [instructions to release to prod](https://github.com/DataBiosphere/bond/blob/develop/README.md#production-deployment-checklist)). Either do this now or create a ticket and schedule the release.
