### PR TITLE
ID-361 Add sentry with flask integration.

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,15 +9,27 @@ import yaml
 from flask_cors import CORS
 from google.auth.credentials import AnonymousCredentials
 from google.cloud import ndb
+from sentry_sdk.integrations.flask import FlaskIntegration
 
 from bond_app import routes
 from bond_app.json_exception_handler import JsonExceptionHandler
 from bond_app.swagger_ui import swaggerui_blueprint, SWAGGER_URL
 
-
-SENTRY_DSN=os.environ.get("SENTRY_DSN")
+SENTRY_DSN = os.environ.get("SENTRY_DSN")
+SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT")
 if SENTRY_DSN is not None:
-    sentry_sdk.init(dsn=SENTRY_DSN)
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        environment=SENTRY_ENVIRONMENT,
+        integrations=[
+            FlaskIntegration(),
+        ],
+        # By default the SDK will try to use the SENTRY_RELEASE
+        # environment variable, or infer a git commit
+        # SHA as release, however you may want to set
+        # something more human-readable.
+        # release="myapp@1.0.0",
+    )
 
 client = None
 if os.environ.get('DATASTORE_EMULATOR_HOST'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ PyYaml==5.4
 jinja2==3.0.3
 itsdangerous==2.0.1
 protobuf==3.20.1
-sentry-sdk==1.11.1
+sentry-sdk[flask]==1.11.1


### PR DESCRIPTION
Bond isnt currently reporting errors to sentry so I suspect that we need to use the flask integration.