### PR TITLE
Revert "[ID-468] upgrade werkzeug version to 2.2.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ googleapis-common-protos==1.52.0
 google-cloud-ndb==1.7.2
 google-cloud-datastore==1.15.3
 Flask==1.1.1
-Werkzeug==2.2.3
+Werkzeug==0.16.0
 webargs==5.5.3
 grpcio==1.48.1
 protorpc==0.12.0


### PR DESCRIPTION
Reverts DataBiosphere/bond#202

started causing test failures https://broadinstitute.slack.com/archives/C03GMG4DUSE/p1678714430607749