### PR TITLE
ID-744 Migrate Bond off AppEngine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ jobs:
           command: |
             docker build -t ${IMAGE_NAME}:${CIRCLE_BRANCH} -f docker/Dockerfile .
             if [[ ${CIRCLE_BRANCH} == "develop" ]]; then docker tag ${IMAGE_NAME}:${CIRCLE_BRANCH} ${IMAGE_NAME}:latest ; fi
+            if [[ ${CIRCLE_BRANCH} == "develop" ]]; then docker tag ${IMAGE_NAME}:${CIRCLE_BRANCH} ${IMAGE_NAME}:${CIRCLE_SHA1:0:12} ; fi
 
       - run:
           name: Run functional tests

--- a/bond_app/authorize.py
+++ b/bond_app/authorize.py
@@ -1,13 +1,13 @@
 import configparser
 from requests_oauthlib import OAuth2Session
 import requests
-import util
+from .util import get_provider_secrets
 
 config = configparser.ConfigParser()
 config.read("config.ini")
 
 provider = 'fence'
-client_id, client_secret = util.get_provider_secrets(config, provider)
+client_id, client_secret = get_provider_secrets(config, provider)
 redirect_uri = "http://local.broadinstitute.org/#fence-callback"
 open_id_config_url = config.get(provider, 'OPEN_ID_CONFIG_URL')
 

--- a/bond_app/authorize.py
+++ b/bond_app/authorize.py
@@ -1,18 +1,13 @@
 import configparser
 from requests_oauthlib import OAuth2Session
 import requests
-import os
+import util
 
 config = configparser.ConfigParser()
 config.read("config.ini")
 
 provider = 'fence'
-if os.environ.get("BOND_ENV_SECRETS"):
-    client_id = os.environ.get(f"{provider}_CLIENT_ID")
-    client_secret = os.environ.get(f"{provider}_CLIENT_SECRET")
-else:
-    client_id = config.get(provider, 'CLIENT_ID')
-    client_secret = config.get(provider, 'CLIENT_SECRET')
+client_id, client_secret = util.get_provider_secrets(config, provider)
 redirect_uri = "http://local.broadinstitute.org/#fence-callback"
 open_id_config_url = config.get(provider, 'OPEN_ID_CONFIG_URL')
 

--- a/bond_app/authorize.py
+++ b/bond_app/authorize.py
@@ -1,14 +1,18 @@
 import configparser
 from requests_oauthlib import OAuth2Session
 import requests
-import json
+import os
 
 config = configparser.ConfigParser()
 config.read("config.ini")
 
 provider = 'fence'
-client_id = config.get(provider, 'CLIENT_ID')
-client_secret = config.get(provider, 'CLIENT_SECRET')
+if os.environ.get("BOND_ENV_SECRETS"):
+    client_id = os.environ.get(f"{provider}_CLIENT_ID")
+    client_secret = os.environ.get(f"{provider}_CLIENT_SECRET")
+else:
+    client_id = config.get(provider, 'CLIENT_ID')
+    client_secret = config.get(provider, 'CLIENT_SECRET')
 redirect_uri = "http://local.broadinstitute.org/#fence-callback"
 open_id_config_url = config.get(provider, 'OPEN_ID_CONFIG_URL')
 

--- a/bond_app/routes.py
+++ b/bond_app/routes.py
@@ -90,8 +90,12 @@ def is_provider(section_name):
 
 
 def create_provider(provider_name):
-    client_id = config.get(provider_name, 'CLIENT_ID')
-    client_secret = config.get(provider_name, 'CLIENT_SECRET')
+    if os.environ.get("BOND_ENV_SECRETS"):
+        client_id = os.environ.get(f"{provider_name}_CLIENT_ID")
+        client_secret = os.environ.get(f"{provider_name}_CLIENT_SECRET")
+    else:
+        client_id = config.get(provider_name, 'CLIENT_ID')
+        client_secret = config.get(provider_name, 'CLIENT_SECRET')
     open_id_config_url = config.get(provider_name, 'OPEN_ID_CONFIG_URL')
     fence_base_url = config.get(provider_name, 'FENCE_BASE_URL')
     user_name_path_expr = config.get(provider_name, 'USER_NAME_PATH_EXPR')

--- a/bond_app/routes.py
+++ b/bond_app/routes.py
@@ -25,7 +25,7 @@ from .token_store import TokenStore
 from .oauth2_state_store import OAuth2StateStore
 import json
 import ast
-import util
+from .util import get_provider_secrets
 
 
 class Parser(FlaskParser):
@@ -91,7 +91,7 @@ def is_provider(section_name):
 
 
 def create_provider(provider_name):
-    client_id, client_secret = util.get_provider_secrets(config, provider_name)
+    client_id, client_secret = get_provider_secrets(config, provider_name)
     open_id_config_url = config.get(provider_name, 'OPEN_ID_CONFIG_URL')
     fence_base_url = config.get(provider_name, 'FENCE_BASE_URL')
     user_name_path_expr = config.get(provider_name, 'USER_NAME_PATH_EXPR')

--- a/bond_app/routes.py
+++ b/bond_app/routes.py
@@ -25,6 +25,7 @@ from .token_store import TokenStore
 from .oauth2_state_store import OAuth2StateStore
 import json
 import ast
+import util
 
 
 class Parser(FlaskParser):
@@ -90,12 +91,7 @@ def is_provider(section_name):
 
 
 def create_provider(provider_name):
-    if os.environ.get("BOND_ENV_SECRETS"):
-        client_id = os.environ.get(f"{provider_name}_CLIENT_ID")
-        client_secret = os.environ.get(f"{provider_name}_CLIENT_SECRET")
-    else:
-        client_id = config.get(provider_name, 'CLIENT_ID')
-        client_secret = config.get(provider_name, 'CLIENT_SECRET')
+    client_id, client_secret = util.get_provider_secrets(config, provider_name)
     open_id_config_url = config.get(provider_name, 'OPEN_ID_CONFIG_URL')
     fence_base_url = config.get(provider_name, 'FENCE_BASE_URL')
     user_name_path_expr = config.get(provider_name, 'USER_NAME_PATH_EXPR')

--- a/bond_app/routes.py
+++ b/bond_app/routes.py
@@ -240,7 +240,13 @@ def get_status():
     status_service = Status(sam_api, providers, cache_api)
 
     subsystems = status_service.get()
-    ok = all(subsystem["ok"] for subsystem in subsystems)
+
+    subsystems_for_ok_status = subsystems.copy()
+    subsystems_to_ignore = os.environ.get('SUBSYSTEMS_TO_IGNORE', '').split(',')
+    for subsystem_to_ignore in subsystems_to_ignore:
+        subsystems_for_ok_status.remove(subsystem_to_ignore)
+
+    ok = all(subsystem["ok"] for subsystem in subsystems_for_ok_status)
     response = json_response(StatusResponse(ok=ok,
                                             subsystems=[SubSystemStatusResponse(ok=subsystem["ok"],
                                                                                 message=subsystem["message"],

--- a/bond_app/routes.py
+++ b/bond_app/routes.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import Blueprint, request
+from flask import Blueprint, request, redirect
 import configparser
 import os
 from werkzeug import exceptions
@@ -255,3 +255,8 @@ def get_status():
     else:
         logging.warning("Bond status NOT OK:\n%s" % response[0])
         raise exceptions.InternalServerError(response[0])
+
+
+@routes.route('/', methods=["GET"], strict_slashes=False)
+def redirect_to_swagger():
+    return redirect('/api/docs')

--- a/bond_app/routes.py
+++ b/bond_app/routes.py
@@ -241,10 +241,8 @@ def get_status():
 
     subsystems = status_service.get()
 
-    subsystems_for_ok_status = subsystems.copy()
     subsystems_to_ignore = os.environ.get('SUBSYSTEMS_TO_IGNORE', '').split(',')
-    for subsystem_to_ignore in subsystems_to_ignore:
-        subsystems_for_ok_status.remove(subsystem_to_ignore)
+    subsystems_for_ok_status = [s for s in subsystems if s['subsystem'] not in subsystems_to_ignore]
 
     ok = all(subsystem["ok"] for subsystem in subsystems_for_ok_status)
     response = json_response(StatusResponse(ok=ok,

--- a/bond_app/util.py
+++ b/bond_app/util.py
@@ -1,0 +1,12 @@
+import os
+
+
+def get_provider_secrets(config, provider: str):
+    if os.environ.get("BOND_ENV_SECRETS"):
+        provider_normalized = provider.upper().replace("-", "_")
+        client_id = os.environ.get(f"{provider_normalized}_CLIENT_ID")
+        client_secret = os.environ.get(f"{provider_normalized}_CLIENT_SECRET")
+    else:
+        client_id = config.get(provider, 'CLIENT_ID')
+        client_secret = config.get(provider, 'CLIENT_SECRET')
+    return client_id, client_secret

--- a/main.py
+++ b/main.py
@@ -39,14 +39,7 @@ if os.environ.get('DATASTORE_EMULATOR_HOST'):
     client = ndb.Client(project="test", credentials=AnonymousCredentials())
 elif os.environ.get('DATASTORE_GOOGLE_PROJECT'):
     project = os.environ.get('DATASTORE_GOOGLE_PROJECT')
-
-    if os.environ.get('DATASTORE_GOOGLE_CREDENTIALS_PATH'):
-        credentials_path = os.environ.get("DATASTORE_GOOGLE_CREDENTIALS_PATH")
-        credentials = service_account.Credentials.from_service_account_file(credentials_path)
-        scoped_credentials = credentials.with_scopes(['https://www.googleapis.com/auth/datastore'])
-        client = ndb.Client(project, None, scoped_credentials)
-    else:
-        client = ndb.Client(project)
+    client = ndb.Client(project)
 else:
     # Otherwise, create a client grabbing credentials normally from cloud environment variables.
     client = ndb.Client()

--- a/main.py
+++ b/main.py
@@ -8,7 +8,6 @@ import sentry_sdk
 import yaml
 from flask_cors import CORS
 from google.auth.credentials import AnonymousCredentials
-from google.oauth2 import service_account
 from google.cloud import ndb
 from sentry_sdk.integrations.flask import FlaskIntegration
 

--- a/main.py
+++ b/main.py
@@ -39,12 +39,14 @@ if os.environ.get('DATASTORE_EMULATOR_HOST'):
     client = ndb.Client(project="test", credentials=AnonymousCredentials())
 elif os.environ.get('DATASTORE_GOOGLE_PROJECT'):
     project = os.environ.get('DATASTORE_GOOGLE_PROJECT')
-    credentials_path = os.environ.get("DATASTORE_GOOGLE_CREDENTIALS_PATH")
 
-    credentials = service_account.Credentials.from_service_account_file(credentials_path)
-
-    scoped_credentials = credentials.with_scopes(['https://www.googleapis.com/auth/datastore'])
-    client = ndb.Client(project, None, scoped_credentials)
+    if os.environ.get('DATASTORE_GOOGLE_CREDENTIALS_PATH'):
+        credentials_path = os.environ.get("DATASTORE_GOOGLE_CREDENTIALS_PATH")
+        credentials = service_account.Credentials.from_service_account_file(credentials_path)
+        scoped_credentials = credentials.with_scopes(['https://www.googleapis.com/auth/datastore'])
+        client = ndb.Client(project, None, scoped_credentials)
+    else:
+        client = ndb.Client(project)
 else:
     # Otherwise, create a client grabbing credentials normally from cloud environment variables.
     client = ndb.Client()

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import sentry_sdk
 import yaml
 from flask_cors import CORS
 from google.auth.credentials import AnonymousCredentials
+from google.oauth2 import service_account
 from google.cloud import ndb
 from sentry_sdk.integrations.flask import FlaskIntegration
 
@@ -36,6 +37,14 @@ if os.environ.get('DATASTORE_EMULATOR_HOST'):
     # If we're running the datastore emulator, we should use anonymous credentials to connect to it.
     # The project should match the project given to the Datastore Emulator. See tests/datastore_emulator/run_emulator.sh
     client = ndb.Client(project="test", credentials=AnonymousCredentials())
+elif os.environ.get('DATASTORE_GOOGLE_PROJECT'):
+    project = os.environ.get('DATASTORE_GOOGLE_PROJECT')
+    credentials_path = os.environ.get("DATASTORE_GOOGLE_CREDENTIALS_PATH")
+
+    credentials = service_account.Credentials.from_service_account_file(credentials_path)
+
+    scoped_credentials = credentials.with_scopes(['https://www.googleapis.com/auth/datastore'])
+    client = ndb.Client(project, None, scoped_credentials)
 else:
     # Otherwise, create a client grabbing credentials normally from cloud environment variables.
     client = ndb.Client()

--- a/run_local.sh
+++ b/run_local.sh
@@ -2,7 +2,7 @@
 
 export FLASK_APP=main.py
 # Configure the app to talk to the Datastore Emulator.
-export DATASTORE_EMULATOR_HOST=0.0.0.0:8432
+#export DATASTORE_EMULATOR_HOST=0.0.0.0:8432
 
 FLASK_HOST="${1:-127.0.0.1}"
 

--- a/tests/integration/oauth_adapter_test.py
+++ b/tests/integration/oauth_adapter_test.py
@@ -3,6 +3,7 @@ import re
 import sys
 import time
 import unittest
+import os
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -35,8 +36,12 @@ class OauthAdapterTestCase(unittest.TestCase):
         oauth_adapters = {}
         for section in config.sections():
             if section != "sam" and section != "bond_accepted":
-                client_id = config.get(section, 'CLIENT_ID')
-                client_secret = config.get(section, 'CLIENT_SECRET')
+                if os.environ.get("BOND_ENV_SECRETS"):
+                    client_id = os.environ.get(f"{section}_CLIENT_ID")
+                    client_secret = os.environ.get(f"{section}_CLIENT_SECRET")
+                else:
+                    client_id = config.get(section, 'CLIENT_ID')
+                    client_secret = config.get(section, 'CLIENT_SECRET')
                 open_id_config_url = config.get(section, 'OPEN_ID_CONFIG_URL')
                 open_id_config = OpenIdConfig(section, open_id_config_url, FakeCacheApi())
                 oauth_adapters[section] = OauthAdapter(client_id, client_secret, open_id_config, section)

--- a/tests/integration/oauth_adapter_test.py
+++ b/tests/integration/oauth_adapter_test.py
@@ -3,7 +3,7 @@ import re
 import sys
 import time
 import unittest
-import os
+import bond_app.util as util
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -36,12 +36,7 @@ class OauthAdapterTestCase(unittest.TestCase):
         oauth_adapters = {}
         for section in config.sections():
             if section != "sam" and section != "bond_accepted":
-                if os.environ.get("BOND_ENV_SECRETS"):
-                    client_id = os.environ.get(f"{section}_CLIENT_ID")
-                    client_secret = os.environ.get(f"{section}_CLIENT_SECRET")
-                else:
-                    client_id = config.get(section, 'CLIENT_ID')
-                    client_secret = config.get(section, 'CLIENT_SECRET')
+                client_id, client_secret = util.get_provider_secrets(config, section)
                 open_id_config_url = config.get(section, 'OPEN_ID_CONFIG_URL')
                 open_id_config = OpenIdConfig(section, open_id_config_url, FakeCacheApi())
                 oauth_adapters[section] = OauthAdapter(client_id, client_secret, open_id_config, section)


### PR DESCRIPTION
What:

Makes some backwards-compatible changes to Bond to enable its running on Kubernetes instead of AppEngine.

https://broadworkbench.atlassian.net/browse/ID-744

Why:

Bond running in AppEngine doesn't conform to our current stack. Making it run in Kubernetes will let Yale rotate its service account keys, let Sherlock and Beehive control its deployment, and make it conform to the deployment of the rest of our services.

How:

Make Bond able to talk to a different Datastore from the project its deployed in. Also, allowed it to pull secrets from environment variables instead of relying on a config file stored in Vault. Telling Bond to ignore AnVIL in dev is now possible, so that status in dev returns `OK`. Added a redirect to `/` endpoint so that it redirects to the Swagger docs, a nice QoL improvement.

---

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary. 
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
- [x] **Release to production** - Releasing to prod is a manual process (see [instructions to release to prod](https://github.com/DataBiosphere/bond/blob/develop/README.md#production-deployment-checklist)). Either do this now or create a ticket and schedule the release.
