### PR TITLE
ID-874 Fix Bond Sam Cache

### DIFF
--- a/bond_app/authentication.py
+++ b/bond_app/authentication.py
@@ -54,6 +54,7 @@ class Authentication:
             raise exceptions.Unauthorized('Malformed Authorization header, must be in the form of "bearer [token]".')
 
         token = auth_header_parts[1]
+        # SHA256 the token so that it's a consistent length guaranteed to be less that 1500 bytes.
         cache_key = hashlib.sha256(str.encode(token)).hexdigest()
 
         # First check cache for Sam user info.

--- a/bond_app/authentication.py
+++ b/bond_app/authentication.py
@@ -54,7 +54,7 @@ class Authentication:
             raise exceptions.Unauthorized('Malformed Authorization header, must be in the form of "bearer [token]".')
 
         token = auth_header_parts[1]
-        cache_key = hashlib.sha256(token).hexdigest()
+        cache_key = hashlib.sha256(str.encode(token)).hexdigest()
 
         # First check cache for Sam user info.
         sam_user_info = self.cache_api.get(namespace="SamUserInfo", key=cache_key)

--- a/tests/unit/authentication_test.py
+++ b/tests/unit/authentication_test.py
@@ -1,3 +1,4 @@
+import hashlib
 import unittest
 
 from werkzeug import exceptions
@@ -28,6 +29,7 @@ class AuthenticationTestCase(unittest.TestCase):
         # set up mock Sam
         token = "testtoken"
         expected_user_info = UserInfo("193481341723041", "foo@bar.com", token, 100)
+        cache_key = hashlib.sha256(str.encode(token)).hexdigest()
         sam_user_info = self._generate_sam_user_info(expected_user_info.id, expected_user_info.email, True)
         self.sam_api.user_info = MagicMock(return_value=sam_user_info)
 
@@ -36,15 +38,16 @@ class AuthenticationTestCase(unittest.TestCase):
         self.assertEqual(expected_user_info.id, sam_user_id)
 
         # sam user info should now be cached
-        cached_sam_user_info = self.cache_api.get(namespace="SamUserInfo", key=token)
+        cached_sam_user_info = self.cache_api.get(namespace="SamUserInfo", key=cache_key)
         self.assertEqual(sam_user_info, cached_sam_user_info)
 
     def test_good_user_sam_info_cached(self):
         # populate cache
         token = "testtoken"
         expected_user_info = UserInfo("193481341723041", "foo@bar.com", token, 100)
+        cache_key = hashlib.sha256(str.encode(token)).hexdigest()
         sam_user_info = self._generate_sam_user_info(expected_user_info.id, expected_user_info.email, True)
-        self.cache_api.add(namespace="SamUserInfo", key=token, expires_in=0, value=sam_user_info)
+        self.cache_api.add(namespace="SamUserInfo", key=cache_key, expires_in=0, value=sam_user_info)
 
         # set up mock Sam to throw an exception
         mock = MagicMock()
@@ -56,15 +59,16 @@ class AuthenticationTestCase(unittest.TestCase):
         self.assertEqual(expected_user_info.id, sam_user_id)
 
         # sam user info should still be cached
-        cached_sam_user_info = self.cache_api.get(namespace="SamUserInfo", key=token)
+        cached_sam_user_info = self.cache_api.get(namespace="SamUserInfo", key=cache_key)
         self.assertEqual(sam_user_info, cached_sam_user_info)
 
     def test_good_user_cache_expire_config(self):
         # populate cache with 1 second expiry
         token = "testtoken"
         expected_user_info = UserInfo("193481341723041", "foo@bar.com", token, 100)
+        cache_key = hashlib.sha256(str.encode(token)).hexdigest()
         sam_user_info = self._generate_sam_user_info(expected_user_info.id, expected_user_info.email, True)
-        self.cache_api.add(namespace="SamUserInfo", key=token, expires_in=1, value=sam_user_info)
+        self.cache_api.add(namespace="SamUserInfo", key=cache_key, expires_in=1, value=sam_user_info)
 
         # set up mock Sam to throw an exception
         mock = MagicMock()


### PR DESCRIPTION
What:

https://broadworkbench.atlassian.net/browse/ID-874

Bond seems unable to store the responses from Sam in it's cache. Lets fix that!

Why:

Performance improvements

How:

Make sure the cache key isn't too long for starters. Using SHA256 because MD5 could lead to a user being able to create a hash collision to impersonate a user.

---

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
- [ ] **Release to production** - Releasing to prod is a manual process (see [instructions to release to prod](https://github.com/DataBiosphere/bond/blob/develop/README.md#production-deployment-checklist)). Either do this now or create a ticket and schedule the release.
