### PR TITLE
ID-744 Set Up Startup Logging

### DIFF
--- a/bond_app/datastore_cache_api.py
+++ b/bond_app/datastore_cache_api.py
@@ -52,8 +52,12 @@ class DatastoreCacheApi(CacheApi):
     def delete_expired_entries():
         """Deletes the entries that have expired. This must be done periodically. """
         expired_entries = CacheEntry.query(CacheEntry.expires_at < datetime.datetime.now())
-        deletions = ndb.delete_multi([key for key in expired_entries.iter(keys_only=True)])
-        logging.info("Deleted %d cache entries.", len(deletions))
+        logging.info("Found %d expired cache entries.", expired_entries.count())
+        try:
+            deletions = ndb.delete_multi([key for key in expired_entries.iter(keys_only=True)])
+            logging.info("Deleted %d cache entries.", len(deletions))
+        except Exception as e:
+            logging.error("Failed to delete expired cache entries: %s", e)
 
     @staticmethod
     def _build_cache_key(key, namespace):

--- a/main.py
+++ b/main.py
@@ -89,14 +89,17 @@ def setup_logging():
                           .format(log_config_file_path))
 
     logging.config.dictConfig(logging_config)
+    logging.info("Logging configured")
 
 
 def create_app():
     """Initializes app."""
+    logging.info("Creating Flask app")
     flask_app = flask.Flask(__name__)
     flask_app.register_blueprint(routes.routes)
     flask_app.register_blueprint(swaggerui_blueprint, url_prefix=SWAGGER_URL)
     CORS(flask_app)
+    logging.info("Flask app created")
     return flask_app
 
 


### PR DESCRIPTION
What:

Add some logging on startup to help diagnose instability in k8s.

Why:

Knowing when Bond starts up in the logs will help us diagnose issues with the cron job.

How:

Just adding some logging.
---

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
- [ ] **Release to production** - Releasing to prod is a manual process (see [instructions to release to prod](https://github.com/DataBiosphere/bond/blob/develop/README.md#production-deployment-checklist)). Either do this now or create a ticket and schedule the release.
