### PR TITLE
ID-1002 Remove Cronjob in favor of Datastore TTL

### DIFF
--- a/bond_app/datastore_cache_api.py
+++ b/bond_app/datastore_cache_api.py
@@ -2,7 +2,6 @@ import datetime
 from google.cloud import ndb
 from google.api_core.exceptions import InvalidArgument
 from .cache_api import CacheApi
-import logging
 
 _NO_EXPIRATION_DATETIME = datetime.datetime(year=3000, month=1, day=1)
 
@@ -47,17 +46,6 @@ class DatastoreCacheApi(CacheApi):
             DatastoreCacheApi._build_cache_key(key, namespace).delete()
         except InvalidArgument:
             pass
-
-    @staticmethod
-    def delete_expired_entries():
-        """Deletes the entries that have expired. This must be done periodically. """
-        expired_entries = CacheEntry.query(CacheEntry.expires_at < datetime.datetime.now())
-        logging.info("Found %d expired cache entries.", expired_entries.count())
-        try:
-            deletions = ndb.delete_multi([key for key in expired_entries.iter(keys_only=True)])
-            logging.info("Deleted %d cache entries.", len(deletions))
-        except Exception as e:
-            logging.error("Failed to delete expired cache entries: %s", e)
 
     @staticmethod
     def _build_cache_key(key, namespace):

--- a/bond_app/routes.py
+++ b/bond_app/routes.py
@@ -235,15 +235,6 @@ def authorization_url(args, provider):
     return json_response((AuthorizationUrlResponse(url=authz_url)))
 
 
-@routes.route(v1_link_route_base + '/clear-expired-cache-datastore-entries', methods=["GET"], strict_slashes=False)
-def clear_expired_datastore_entries():
-    # Only allow Appengine cron to hit this endpoint.
-    if not request.headers.get("X-Appengine-Cron"):
-        raise exceptions.Forbidden('Missing required cron header.')
-    DatastoreCacheApi.delete_expired_entries()
-    return '', 204
-
-
 @routes.route('/api/status/v1/status', methods=["GET"], strict_slashes=False)
 def get_status():
     sam_base_url = config.get('sam', 'BASE_URL')

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,4 +1,0 @@
-cron:
-  - description: "clear expired Datastore cache entries"
-    url: /api/link/v1/clear-expired-cache-datastore-entries
-    schedule: every 2 hours

--- a/deploy.sh
+++ b/deploy.sh
@@ -70,4 +70,4 @@ docker run -v $PWD/app.yaml:/app/app.yaml \
     -e GOOGLE_PROJECT=${GOOGLE_PROJECT} \
     --entrypoint "/bin/bash" \
     ${BOND_IMAGE} \
-    -c "gcloud auth activate-service-account --key-file=deploy_account.json && gcloud -q app deploy app.yaml --project=$GOOGLE_PROJECT && gcloud -q app deploy cron.yaml --project=$GOOGLE_PROJECT"
+    -c "gcloud auth activate-service-account --key-file=deploy_account.json && gcloud -q app deploy app.yaml --project=$GOOGLE_PROJECT"

--- a/tests/datastore_emulator/datastore_cache_api_test.py
+++ b/tests/datastore_emulator/datastore_cache_api_test.py
@@ -13,30 +13,6 @@ class DatstoreCacheApiTestCase(unittest.TestCase, cache_api_test.CacheApiTest):
         datastore_emulator_utils.setUp(self)
         self.setUpCache(DatastoreCacheApi())
 
-    def test_delete_removes_expired_entries(self):
-        cache = DatastoreCacheApi()
-
-        cache.add("foo", "foo_value", expires_in=0.5)
-        cache.add("foo_namespace", "foo_namespace_value", expires_in=0.5, namespace="baz")
-        cache.add("not_expired", "not_expired_value", expires_in=100)
-        cache.add("no_expiration", "no_expiration_value")
-
-        foo_key = DatastoreCacheApi._build_cache_key("foo", None)
-        self.assertIsNotNone(foo_key.get())
-
-        time.sleep(1)
-
-        # Value expired, but entry is still present in Datastore.
-        self.assertIsNone(cache.get("foo"))
-        self.assertIsNotNone(foo_key.get())
-
-        cache.delete_expired_entries()
-
-        self.assertIsNone(foo_key.get())
-        self.assertIsNone(DatastoreCacheApi._build_cache_key("foo_namespace", "baz").get())
-        self.assertIsNotNone(DatastoreCacheApi._build_cache_key("not_expired", None).get())
-        self.assertIsNotNone(DatastoreCacheApi._build_cache_key("no_expiration", None).get())
-
     def test_large_keys(self):
         cache = DatastoreCacheApi()
 


### PR DESCRIPTION
What:

https://broadworkbench.atlassian.net/browse/ID-1002

Removing the cronjob that deletes expired cache entries and the supporting code in Bond.

Why:

Since March 2020, Bond has been failing to delete expired cache entries. I tries to delete them synchronously, but fails, as there are now ~2.5 million entries. Datastore has a TTL feature that looks at `expired_at` properties and automatically deletes entries who's timestamp is less than `now()`. Bond will now rely on this to clean up it's cache entries.

It looks like doing this will greatly increase the stability of Bond in Prod and remove the constant alerts in the identiteam-alerts slack channel.

---

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
- [ ] **Release to production** - Releasing to prod is a manual process (see [instructions to release to prod](https://github.com/DataBiosphere/bond/blob/develop/README.md#production-deployment-checklist)). Either do this now or create a ticket and schedule the release.
