### PR TITLE
ID-1011 Make Bond only return Status 500 if critical subsystems are down

### DIFF
--- a/bond_app/routes.py
+++ b/bond_app/routes.py
@@ -257,6 +257,11 @@ def get_status():
                                                                                 message=subsystem["message"],
                                                                                 subsystem=subsystem["subsystem"])
                                                         for subsystem in subsystems]))
+
+    failing_subsystems = [subsystem for subsystem in subsystems if not subsystem["ok"]]
+    for failing_subsystem in failing_subsystems:
+        logging.warning("Subsystem %s is not OK: %s" % (failing_subsystem["subsystem"], failing_subsystem))
+
     if critical_subsystems_ok:
         return response
     else:


### PR DESCRIPTION
What:

https://broadworkbench.atlassian.net/browse/ID-1011

If a fence provider goes down, don't take Bond down with it.

Why:

Bond fails for everyone if one provider goes down.

How:

Make Bond only restart if Sam or Datastore goes down.

---

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
- [ ] **Release to production** - Releasing to prod is a manual process (see [instructions to release to prod](https://github.com/DataBiosphere/bond/blob/develop/README.md#production-deployment-checklist)). Either do this now or create a ticket and schedule the release.
