### PR TITLE
[ID-1014] Auto deploy to dev + fixes

### DIFF
--- a/.github/workflows/build-test-tag.yaml
+++ b/.github/workflows/build-test-tag.yaml
@@ -3,7 +3,7 @@ name: Build, test, and tag docker image
 on:
   push:
     branches:
-      - '*'
+      - '**'
     tags-ignore:
       - '**'
     paths-ignore:

--- a/.github/workflows/build-test-tag.yaml
+++ b/.github/workflows/build-test-tag.yaml
@@ -2,6 +2,8 @@ name: Build, test, and tag docker image
 
 on:
   push:
+    branches:
+      - '*'
     tags-ignore:
       - '**'
     paths-ignore:

--- a/.github/workflows/build-test-tag.yaml
+++ b/.github/workflows/build-test-tag.yaml
@@ -204,6 +204,7 @@ jobs:
 
   # Put new Bond version in Broad dev environment.
   set-version-in-dev:
+    if: github.ref_name == github.event.repository.default_branch
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
     needs: [tag-build-publish, report-to-sherlock]
     with:

--- a/.github/workflows/build-test-tag.yaml
+++ b/.github/workflows/build-test-tag.yaml
@@ -2,8 +2,8 @@ name: Build, test, and tag docker image
 
 on:
   push:
-    branches:
-      - develop
+    tags-ignore:
+      - '**'
     paths-ignore:
       - .circleci
       - hooks

--- a/.github/workflows/build-test-tag.yaml
+++ b/.github/workflows/build-test-tag.yaml
@@ -2,6 +2,8 @@ name: Build, test, and tag docker image
 
 on:
   push:
+    branches:
+      - develop
     paths-ignore:
       - .circleci
       - hooks
@@ -66,7 +68,6 @@ jobs:
         uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
         id: tag
         env:
-          INITIAL_VERSION: 1.7.7
           WITH_V: true
           DEFAULT_BUMP: patch
           RELEASE_BRANCHES: ${{ github.event.repository.default_branch }}
@@ -198,3 +199,16 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
+
+  # Put new Bond version in Broad dev environment.
+  set-version-in-dev:
+    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+    needs: [tag-build-publish, report-to-sherlock]
+    with:
+      new-version: ${{ needs.tag-build-publish.outputs.tag }}
+      chart-name: 'bond'
+      environment-name: 'dev'
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: 'write'


### PR DESCRIPTION
### Ticket
https://broadworkbench.atlassian.net/browse/ID-1014

### What
Now that Bond is building images with GHA and tagging them successfully, we can do a few things:
* Remove the `INITIAL_VERSION` setting on the bumper action as it will read git tags to determine the current version
* Auto deploy new versions of Bond in dev
* Only run the GHAs on pushes to `develop`. Due to the "tag dev_tests_passed" job, the GHAs are getting run twice, so let's not do that.

### Testing
This will cut a new version of Bond but no code changes are present so the testing was accidentally deploying to dev from one of these commits before I changed the logic to only deploy to dev on merge to `develop`. It did work correctly, but dev got borked bc it had an invalid version tag set, which will not be an issue after merging the below linked PR as well as this one.

### Prereqs
[This PR](https://github.com/broadinstitute/terra-helmfile/pull/4940) needs to be merged before this one so they will go out together. There may be a bit where dev gets borked, but since prod is still in GAE, I think that's fine.

---

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary. 
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
- [x] **Release to production** - Releasing to prod is a manual process (see [instructions to release to prod](https://github.com/DataBiosphere/bond/blob/develop/README.md#production-deployment-checklist)). Either do this now or create a ticket and schedule the release.
