### PR TITLE
ID-1012 Fix bond error logging.

### DIFF
--- a/log_config.yaml
+++ b/log_config.yaml
@@ -15,7 +15,12 @@ formatters:
 handlers:
   console:
     class: logging.StreamHandler
-    level: NOTSET
+    level: DEBUG
+    formatter: simple
+    stream: ext://sys.stdout
+  error:
+    class: logging.StreamHandler
+    level: ERROR
     formatter: simple
     stream: ext://sys.stderr
 
@@ -27,4 +32,4 @@ loggers:
 
 root:
   level: INFO
-  handlers: [console]
+  handlers: [console, error]

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ requests==2.28.1
 requests-oauthlib==1.3.1
 requests-toolbelt==0.10.1
 rsa==4.9
-sentry-sdk==1.37.1
+sentry-sdk[flask]==1.39.2
 six==1.16.0
 typing_extensions==4.5.0
 urllib3==1.26.14


### PR DESCRIPTION
[ID-1012](https://broadworkbench.atlassian.net/browse/ID-1012)

What:

I am reconfiguring log levels to go to the appropriate output, stdout vs stderr.

I also upgraded sentry and specified the flask sub package, i am not positive this will make a difference but i figured it cant hurt. 

Why:

All logs are showing as ERROR level in gcp because it looks like they are all being directed to stderr.
How:

Reconfiguring log_config.yaml

---

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
- [ ] **Release to production** - Releasing to prod is a manual process (see [instructions to release to prod](https://github.com/DataBiosphere/bond/blob/develop/README.md#production-deployment-checklist)). Either do this now or create a ticket and schedule the release.


[ID-1012]: https://broadworkbench.atlassian.net/browse/ID-1012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ