### PR TITLE
Increase gunicorn timeout and workers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,4 +32,4 @@ COPY . .
 
 # Bond Endpoints available on port 8080.  Admin interface not exposed
 EXPOSE 8080
-CMD gunicorn -b :8080 main:app
+CMD gunicorn -b :8080 --timeout 60 --workers 4 main:app


### PR DESCRIPTION
Eeek. Looks like Gunicorn’s default number of workers is 1. 1!!! Which means if it times out, it restarts that worker, and if its the only worker, the entire flask app goes kaput!

Increasing the timeout and workers should help Bond's stability.

---

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
- [ ] **Release to production** - Releasing to prod is a manual process (see [instructions to release to prod](https://github.com/DataBiosphere/bond/blob/develop/README.md#production-deployment-checklist)). Either do this now or create a ticket and schedule the release.
