### PR TITLE
ID-1072 Investigate Invalid Nonce Errors

### DIFF
--- a/bond_app/oauth2_state_store.py
+++ b/bond_app/oauth2_state_store.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import logging
 import secrets
 from google.cloud import ndb
 from dataclasses import dataclass
@@ -38,16 +39,24 @@ class OAuth2StateStore:
         :param nonce: random value for csrf protection
         """
         oauth2_nonce = OAuth2State(key=OAuth2StateStore._oauth2_state_store_key(user_id, provider), nonce=nonce)
+        logging.info(f"Saving OAuth2State for user {user_id} and provider {provider}")
         oauth2_nonce.put()
 
     def validate_and_delete(self, user_id, provider_name, nonce) -> bool:
         key = OAuth2StateStore._oauth2_state_store_key(user_id, provider_name)
-        oauth2_state = key.get(read_consistency=ndb.EVENTUAL)
+        oauth2_state = key.get()
         if oauth2_state is None:
+            logging.warning(f"Could not find OAuth2State for user {user_id} and provider {provider_name}")
             return False
         else:
+            logging.info(f"Found OAuth2State for user {user_id} and provider {provider_name}. Deleting the state.")
             key.delete()
-            return oauth2_state.nonce == nonce
+            if oauth2_state.nonce != nonce:
+                logging.warning(f"Nonce mismatch for user {user_id} and provider {provider_name}")
+                return False
+            else:
+                logging.info(f"Nonce matched for user {user_id} and provider {provider_name}")
+                return True
 
     def state_with_nonce(self, state):
         if not state:

--- a/bond_app/oauth2_state_store.py
+++ b/bond_app/oauth2_state_store.py
@@ -42,7 +42,7 @@ class OAuth2StateStore:
 
     def validate_and_delete(self, user_id, provider_name, nonce) -> bool:
         key = OAuth2StateStore._oauth2_state_store_key(user_id, provider_name)
-        oauth2_state = key.get()
+        oauth2_state = key.get(read_consistency=ndb.EVENTUAL)
         if oauth2_state is None:
             return False
         else:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-1072

~Google Datastore is eventually consistent, and the `get` method in the NDB Client *does not wait for eventual consistency*. I'm guessing this is the reason why, the more Bond replicas running, the more we see `Invalid nonce` errors.~

NDB might be doing the right thing, so lets just add logging to try and diagnose the problem.

---

Have you read [CONTRIBUTING.md](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/bond/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary. 
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
- [ ] **Release to production** - Releasing to prod is a manual process (see [instructions to release to prod](https://github.com/DataBiosphere/bond/blob/develop/README.md#production-deployment-checklist)). Either do this now or create a ticket and schedule the release.
